### PR TITLE
docs: 测试人 3 — 对话交互与质量控制测试用例与流程图

### DIFF
--- a/docs/tasks/tester-3-flow-diagrams.md
+++ b/docs/tasks/tester-3-flow-diagrams.md
@@ -1,0 +1,321 @@
+# 测试人 3 — P0 测试用例流程图
+
+> 以下 Mermaid 图对应测试人 3 的核心测试场景，
+> 帮助理解对话交互、噪音控制、Lint 集成的内部逻辑和验证点。
+
+---
+
+## 图 1：对话式追问流程（对应 3.1 对话追问 + 3.2 轮次控制）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as 用户
+    participant GH as GitHub<br/>(pull_request_review_comment)
+    participant Dispatcher as CommandDispatcher
+    participant Conv as handleConversation<br/>(conversation.ts)
+    participant Bot as heavyBot
+
+    Note over User: === 3.1.1 行级评论追问 ===
+    User->>GH: 在 Bot 行级评论 thread 中<br/>@codesentinel 为什么这样不好？
+    GH->>Dispatcher: event: pull_request_review_comment
+    Dispatcher->>Dispatcher: parse → 非已注册命令
+    Dispatcher-->>Conv: fallback_conversation
+
+    Conv->>Conv: isFollowUpQuestion(body, BOT_MENTIONS)
+    Note right of Conv: 检查: body 含 @codesentinel<br/>且事件是 review_comment → true
+    Conv->>GH: 收集 thread 历史<br/>(getCommentChain)
+    Conv->>Conv: countBotTurns(chain)
+    
+    alt turns < MAX_CONVERSATION_TURNS (10)
+        Conv->>Conv: truncateConversationChain(chain, MAX_CHAIN_CHARS)
+        Conv->>Bot: chat(prompt + chain + diff_context)
+        Bot-->>Conv: AI 回复
+        Conv->>GH: 回帖到 thread
+    else turns ≥ 10 (测试 3.2.1)
+        Conv->>GH: 回帖 "轮次已达上限"
+    end
+
+    Note over User: === 3.1.3 不带 @bot ===
+    User->>GH: 在 thread 中普通回复<br/>(不含 mention)
+    GH->>Dispatcher: event: pull_request_review_comment
+    Dispatcher->>Dispatcher: parse → kind='none'
+    Note right of Dispatcher: 不含 BOT_MENTIONS → 跳过
+
+    Note over User: === 3.2.4 issue_comment 对话 ===
+    User->>GH: 在 PR 主评论区<br/>@codesentinel 解释一下
+    GH->>Dispatcher: event: issue_comment
+    Dispatcher->>Dispatcher: parse → kind='conversation'
+    Dispatcher-->>Dispatcher: issue_comment 对话暂不支持 → 跳过
+```
+
+### 对话截断策略
+
+```mermaid
+flowchart TD
+    Entry([收集到 thread 历史]) --> CheckLength{chain 总长度<br/>> MAX_CHAIN_CHARS?}
+    
+    CheckLength -->|否| FullChain[使用完整 chain]
+    CheckLength -->|是| Truncate["truncateConversationChain()<br/><small>保留最新 N 条消息<br/>直到总长度 ≤ 12k</small>"]
+    
+    FullChain --> BuildPrompt
+    Truncate --> BuildPrompt
+    
+    BuildPrompt["构建 prompt:<br/>system + PR context<br/>+ file diff<br/>+ truncated chain<br/>+ user question"]
+    BuildPrompt --> CallAI[heavyBot.chat]
+    CallAI --> Reply[回帖到 thread]
+
+    %% 测试标注
+    CheckLength -.- T322["<small>测试 3.2.2: 长对话截断</small>"]
+    Truncate -.- T323["<small>测试 3.2.3: 保留最近内容</small>"]
+
+    classDef decision fill:#fff3e0,stroke:#ff9800
+    classDef action fill:#e3f2fd,stroke:#2196f3
+    class CheckLength decision
+    class Truncate,BuildPrompt,CallAI,Reply action
+```
+
+---
+
+## 图 2：噪音控制流水线（对应 3.3 噪音控制 + 3.5 评论去重）
+
+```mermaid
+flowchart TD
+    Input(["rawFindings: Finding[]<br/><small>Phase 4 逐文件审查产出</small>"]) --> Dedup
+
+    subgraph Dedup [Step 1: 去重]
+        D1["dedupeFindings(findings)"]
+        D1 --> D2{"同文件 + 相似首行?"}
+        D2 -->|是| D3[合并: 保留首条，丢弃重复]
+        D2 -->|否| D4[保留]
+    end
+
+    D3 --> MergeByTopic
+    D4 --> MergeByTopic
+
+    subgraph MergeByTopic [Step 1.5: AI 评论合并]
+        M1["mergeReviewsByTopic()"]
+        M1 --> M2{"同文件 + 相邻行<br/>+ 同一 lint ruleId?"}
+        M2 -->|是| M3["合并: 扩展 startLine~endLine<br/>合并评论文本"]
+        M2 -->|否| M4[保留独立]
+    end
+
+    M3 --> Classify
+    M4 --> Classify
+
+    subgraph Classify [Step 2: 严重级别分类]
+        C1["classifyFindingSeverity(text)"]
+        C1 --> C2["关键词匹配:<br/>security/injection/XSS → critical<br/>error/bug/crash → major<br/>unused/style → minor<br/>nit/typo → nit"]
+        C2 --> C3["附加 severityBadge:<br/>🚨 严重 | ⚠️ 主要<br/>📝 建议 | 💡 微调"]
+    end
+
+    C3 --> Sort
+
+    subgraph Sort [Step 3: 排序]
+        S1["按严重级别降序排列<br/><small>critical > major > minor > nit > info</small>"]
+    end
+
+    S1 --> Truncate
+
+    subgraph Truncate [Step 4: 截断]
+        T1{findings.length<br/>> maxComments?}
+        T1 -->|否| T2[全部保留]
+        T1 -->|是 且 maxComments>0| T3["截断: 保留前 N 条<br/>丢弃尾部低优先级"]
+        T1 -->|maxComments=0| T4[不截断: 全部保留]
+    end
+
+    T2 --> Output
+    T3 --> Output
+    T4 --> Output
+
+    Output(["finalFindings → submitReview<br/><small>排序后的评论列表</small>"])
+
+    %% 测试标注
+    D1 -.- T335["<small>测试 3.3.5: 同类合并</small>"]
+    M1 -.- T351["<small>测试 3.5.1: lint 合并</small>"]
+    C1 -.- T331["<small>测试 3.3.1: 严重级别徽标</small>"]
+    S1 -.- T332["<small>测试 3.3.2: 级别排序</small>"]
+    T3 -.- T333["<small>测试 3.3.3~4: 截断+保留高优</small>"]
+    T4 -.- T336["<small>测试 3.3.6: max=0 不截断</small>"]
+
+    classDef step fill:#e8f5e9,stroke:#4caf50
+    classDef decision fill:#fff3e0,stroke:#ff9800
+    class Dedup,MergeByTopic,Classify,Sort,Truncate step
+    class D2,M2,T1 decision
+```
+
+### 严重级别关键词映射（classifyFindingSeverity）
+
+```mermaid
+flowchart LR
+    Text[评论文本] --> Scan[逐关键词匹配]
+    
+    Scan --> Critical["<b>critical</b><br/>security, injection, XSS,<br/>RCE, command injection,<br/>eval, SQL injection"]
+    Scan --> Major["<b>major</b><br/>error, bug, crash,<br/>undefined, null pointer,<br/>await missing, race condition"]
+    Scan --> Minor["<b>minor</b><br/>unused, refactor,<br/>naming, style, complexity"]
+    Scan --> Nit["<b>nit</b><br/>typo, formatting,<br/>whitespace, prefer"]
+    Scan --> Info["<b>info</b><br/>以上均不匹配 → 默认"]
+
+    Critical --> Badge1["🚨 严重"]
+    Major --> Badge2["⚠️ 主要"]
+    Minor --> Badge3["📝 建议"]
+    Nit --> Badge4["💡 微调"]
+    Info --> Badge5["ℹ️ 信息"]
+```
+
+---
+
+## 图 3：Linter/SAST 集成流程（对应 3.4 Lint 集成）
+
+```mermaid
+flowchart TD
+    Entry([Phase 4 审查开始]) --> LintCheck{enable_lint_tools?}
+    
+    LintCheck -->|false| NoLint[跳过 Lint 阶段<br/>lintContext = '']
+    LintCheck -->|true| Orchestrator
+
+    subgraph Orchestrator [runLintTools — orchestrator.ts]
+        O1[detectLanguage → 选择适用的 Adapters]
+        O1 --> O2{各工具启用状态}
+        
+        O2 -->|enable_eslint| ESLint["ESLint Adapter<br/><small>eslint.ts</small>"]
+        O2 -->|enable_biome| Biome["Biome Adapter<br/><small>biome.ts</small>"]
+        O2 -->|enable_tsc| TSC["tsc Adapter<br/><small>tsc.ts</small>"]
+        O2 -->|enable_prettier| Prettier["Prettier Adapter<br/><small>prettier.ts</small>"]
+        O2 -->|enable_semgrep| Semgrep["Semgrep Adapter<br/><small>semgrep.ts</small>"]
+        
+        ESLint --> Results
+        Biome --> Results
+        TSC --> Results
+        Prettier --> Results
+        Semgrep --> Results
+        
+        Results["LintResult[]<br/><small>{ruleId, message, line, severity}</small>"]
+    end
+
+    Results --> Filter
+
+    subgraph Filter [lint-filter.ts]
+        F1["filterLintResults():<br/>只保留与 PR diff 行重叠的 findings"]
+    end
+
+    Filter --> Format
+
+    subgraph Format [formatter.ts]
+        F2["formatLintContextForFile():<br/>格式化为 prompt 注入文本"]
+        F2 --> F3["formatToolAttribution():<br/>生成 🧰 Tools 卡片"]
+    end
+
+    F3 --> Inject["注入到 reviewFileDiff prompt:<br/>$lint_section + $lint_mandatory_instruction"]
+    NoLint --> ReviewPrompt["reviewFileDiff prompt<br/>(无 lint section)"]
+    Inject --> ReviewPrompt
+
+    ReviewPrompt --> AI["heavyBot.chat → 行级评论"]
+
+    %% 测试标注
+    LintCheck -.- T345["<small>测试 3.4.5: 总开关关闭</small>"]
+    O2 -.- T346["<small>测试 3.4.6: 单独禁用</small>"]
+    ESLint -.- T341["<small>测试 3.4.1: ESLint</small>"]
+    TSC -.- T342["<small>测试 3.4.2: tsc</small>"]
+    Biome -.- T343["<small>测试 3.4.3: Biome</small>"]
+    Semgrep -.- T347["<small>测试 3.4.7: Semgrep</small>"]
+    F3 -.- T344["<small>测试 3.4.4: 工具归因卡片</small>"]
+
+    classDef step fill:#e8f5e9,stroke:#4caf50
+    classDef decision fill:#fff3e0,stroke:#ff9800
+    classDef skip fill:#fee,stroke:#f66
+    class Orchestrator,Filter,Format step
+    class LintCheck,O2 decision
+    class NoLint skip
+```
+
+### 工具归因卡片结构（formatToolAttribution）
+
+```mermaid
+flowchart LR
+    Report["LintReport"] --> Check{"有 lint findings?"}
+    Check -->|否| None["(不输出 Tools 卡片)"]
+    Check -->|是| Build["构建卡片"]
+    Build --> Output["<pre>🧰 Tools<br/>- ESLint (3 findings)<br/>- tsc (1 finding)</pre>"]
+```
+
+---
+
+## 图 4：Web 搜索与 Shell 执行（对应 3.6）
+
+```mermaid
+flowchart TD
+    Review([heavyBot.chat 审查]) --> ToolDecision{"AI 判断是否需要<br/>工具调用?"}
+    
+    ToolDecision -->|需要验证 API 用法| WebSearch
+    ToolDecision -->|需要检查依赖/版本| Shell
+    ToolDecision -->|无需工具| DirectReply[直接输出评论]
+
+    subgraph WebSearch [Web Search — enableWebSearch]
+        WS1["发起 web_search_call"]
+        WS1 --> WS2["搜索最新文档/API 用法"]
+        WS2 --> WS3["将结果注入上下文"]
+    end
+
+    subgraph Shell [Shell 执行 — enableShell]
+        SH1["发起 shell_call"]
+        SH1 --> SH2["执行命令<br/><small>如 npm info / cat package.json</small>"]
+        SH2 --> SH3["将结果注入上下文"]
+    end
+
+    WS3 --> AIResponse["AI 基于搜索/Shell 结果生成评论"]
+    SH3 --> AIResponse
+    DirectReply --> Done
+    AIResponse --> Done([输出行级评论])
+
+    %% Analysis steps 记录
+    WS1 -.- AS1["AnalysisStep: type='web_search'"]
+    SH1 -.- AS2["AnalysisStep: type='shell'"]
+
+    %% 测试标注
+    WebSearch -.- T361["<small>测试 3.6.1: web search 触发</small>"]
+    Shell -.- T362["<small>测试 3.6.2: shell 执行</small>"]
+
+    classDef tool fill:#e3f2fd,stroke:#2196f3
+    classDef decision fill:#fff3e0,stroke:#ff9800
+    class WebSearch,Shell tool
+    class ToolDecision decision
+```
+
+---
+
+## 测试覆盖映射总表
+
+| 测试编号 | 测试场景 | 对应图中节点 |
+|----------|----------|--------------|
+| 3.1.1 | 行级评论追问 | 图1: User → Conv → Bot → Reply 完整路径 |
+| 3.1.2 | 续轮追问 | 图1: 多次循环（chain 累积） |
+| 3.1.3 | 不带 @bot 不触发 | 图1: parse → kind='none' → 跳过 |
+| 3.1.4 | Bot 不自触发 | 图1: Dispatcher 过滤 Bot 身份 |
+| 3.1.5 | 引用文件 diff | 图1: BuildPrompt (file diff) |
+| 3.1.6 | 引用 PR 摘要 | 图1: BuildPrompt (PR context) |
+| 3.2.1 | 10 轮限制 | 图1: countBotTurns ≥ 10 分支 |
+| 3.2.2 | 长对话截断 | 截断策略图: CheckLength → Truncate |
+| 3.2.3 | 保留最近内容 | 截断策略图: 从尾部保留 |
+| 3.2.4 | issue_comment 不支持 | 图1: issue_comment → 跳过 |
+| 3.3.1 | 严重级别徽标 | 图2: Classify → Badge |
+| 3.3.2 | 级别排序 | 图2: Sort |
+| 3.3.3 | 评论截断 | 图2: Truncate (maxComments) |
+| 3.3.4 | 截断保留高优 | 图2: Sort → Truncate 顺序保证 |
+| 3.3.5 | 同类合并 | 图2: Dedup |
+| 3.3.6 | 不截断(max=0) | 图2: Truncate maxComments=0 分支 |
+| 3.4.1 | ESLint | 图3: ESLint Adapter |
+| 3.4.2 | tsc | 图3: tsc Adapter |
+| 3.4.3 | Biome | 图3: Biome Adapter |
+| 3.4.4 | 工具归因卡片 | 图3: formatToolAttribution |
+| 3.4.5 | lint 总开关 | 图3: enable_lint_tools → false |
+| 3.4.6 | 单独禁用 | 图3: O2 各开关 |
+| 3.4.7 | Semgrep | 图3: Semgrep Adapter |
+| 3.5.1 | lint 合并 | 图2: MergeByTopic (同 ruleId) |
+| 3.5.2 | 不同 lint 不合并 | 图2: MergeByTopic (不同 ruleId) |
+| 3.5.3 | 合并行号扩展 | 图2: M3 扩展 startLine~endLine |
+| 3.5.4 | AI 同行去重 | 图2: Dedup (同首行) |
+| 3.6.1 | Web 搜索 | 图4: WebSearch |
+| 3.6.2 | Shell 执行 | 图4: Shell |
+| 3.6.3 | 关闭 web search | 图4: enableWebSearch=false → 无 web_search |
+| 3.6.4 | 关闭 shell | 图4: enableShell=false → 无 shell |

--- a/docs/tasks/tester-3-quality-control-testcases.md
+++ b/docs/tasks/tester-3-quality-control-testcases.md
@@ -1,0 +1,468 @@
+# 测试人 3 — 对话交互与质量控制：完整测试用例与验证方案
+
+> **负责范围**: 对话追问 + 噪音控制 + AI 评论去重 + Linter/SAST 集成 + Web 搜索 + Shell 执行
+> **测试仓库**: `ai-reviewer-test` (`/Users/anton/Developer/CodesSentinels/ai-reviewer-test`)
+> **触发规则**: PR target 到 `main` 或 `test/dev*`；push 到 `main` 或 `test/dev*`
+
+---
+
+## 测试环境说明
+
+| 项 | 值 |
+|---|---|
+| Workflow 配置 | `.github/workflows/ai-reviewer.yml` |
+| 触发分支规则 | PR target: `main` / `test/dev*`；push: `main` / `test/dev*` |
+| 核心源文件 | `src/conversation.ts`, `src/noise-control.ts`, `src/review-dedup.ts`, `src/lint/` |
+| 当前启用功能 | `enable_lint_tools: true`, `enable_web_search: true`, `enable_shell: true` |
+| 模型 | heavyBot: `gpt-5.4-mini` |
+| 相关配置 | `max_review_comments: 20`, `MAX_CONVERSATION_TURNS: 10`, `MAX_CHAIN_CHARS: 12000` |
+
+---
+
+## 3.1 对话式追问交互（P0）
+
+| # | 场景 | 验证点 | 操作步骤 | 预期结果 |
+|---|------|--------|----------|----------|
+| 3.1.1 | 行级评论追问 | Bot 回复，引用该行代码上下文 | 在 Bot 产出的行级评论 thread 中评论 `@codesentinel 为什么这样不好？` | Bot 回帖引用对应代码行 + 具体解释 |
+| 3.1.2 | 续轮追问 | 多轮上下文保持 | 在同一 thread 继续 `@codesentinel 怎么改？` | Bot 回复含修改建议，引用上一轮对话内容 |
+| 3.1.3 | 不带 @bot 的回复 | Bot 不触发 | 在 thread 中直接回复（不含 mention） | Bot 无任何响应 |
+| 3.1.4 | Bot 自回复不自触发 | 无无限循环 | 等待 Bot 回帖，观察 Actions 日志 | Bot 回帖后无新 workflow run |
+| 3.1.5 | 追问引用文件完整 diff | 回复能感知整体变更 | 追问跨行的架构问题（如 "这个重构的整体思路是什么"） | 回复内容涵盖多行变更的上下文 |
+| 3.1.6 | 追问引用 PR 摘要 | 回复关联 PR 目的 | 追问 "这个改动和 PR 目标有什么关系" | 回复引用 PR title/description 中的信息 |
+
+### 验证代码 — 案例 3.1.1 ~ 3.1.2
+
+先用以下代码触发 Bot 产出行级评论作为对话锚点：
+
+```typescript
+// conversation-anchor.ts — 设计为可追问的代码
+export function processPayment(amount: number, userId: string) {
+  // 安全问题：金额未做校验
+  if (amount) {
+    const query = `UPDATE balance SET amount = ${amount} WHERE user = '${userId}'`
+    return executeQuery(query)
+  }
+}
+
+export function generateToken(): string {
+  // 安全问题：使用 Math.random 生成 token
+  return Math.random().toString(36).slice(2)
+}
+```
+
+**对话追问流程**（在 Bot 产出的 `processPayment` 评论 thread 中执行）：
+1. `@codesentinel 为什么直接拼接 SQL 是个问题？可以具体说说攻击场景吗？`
+2. (等 Bot 回复后) `@codesentinel 用参数化查询的话，这段代码应该怎么改？`
+
+---
+
+## 3.2 对话轮次与截断（P1）
+
+| # | 场景 | 验证点 | 操作步骤 | 预期结果 |
+|---|------|--------|----------|----------|
+| 3.2.1 | 连续追问达 10 轮 | 第 11 轮被拒 | 在同一 thread 循环追问 11 次 | 第 11 次收到 "轮次已达上限" 提示 |
+| 3.2.2 | 长对话上下文截断 | Bot 仍能正常回复 | 每轮发 500+ 字长文追问 | Bot 不报 token 超限，回复合理 |
+| 3.2.3 | 截断后保留最近内容 | 引用最近几轮 | 第 8 轮追问引用第 7 轮内容 | 回复关联最近对话而非第 1 轮 |
+| 3.2.4 | issue_comment 对话不支持 | 无响应 | 在 PR 主评论区（非行级 thread）输入 `@codesentinel 解释一下` | Bot 不回复（仅 pull_request_review_comment 支持对话） |
+
+### 关键常量
+
+```
+MAX_CONVERSATION_TURNS = 10   // 单 thread 最多 10 轮 Bot 回复
+MAX_CHAIN_CHARS = 12_000      // 对话链超过 12k 字符时截断
+```
+
+---
+
+## 3.3 噪音控制（P0）
+
+| # | 场景 | 验证点 | 操作步骤 | 预期结果 |
+|---|------|--------|----------|----------|
+| 3.3.1 | 严重级别徽标 | 评论顶部有对应 emoji + 中文标签 | 检查 Bot 行级评论格式 | 如 `🚨 严重` / `⚠️ 主要` / `📝 建议` / `💡 微调` |
+| 3.3.2 | 级别排序 | critical > major > minor > nit | 多种问题混合的 PR，检查评论发布顺序 | critical 评论排在前，nit 排在后 |
+| 3.3.3 | 评论数量截断 | 超过 `max_review_comments`(20) 时截断 | 提交包含 25+ 问题的代码 | 最多 20 条评论，摘要中提示 "N 条评论已省略" |
+| 3.3.4 | 截断保留高优先级 | critical/major 不被截断丢弃 | 代码中混入 3 条 critical + 22 条 nit | critical 全部保留，被截断的是低优先级 |
+| 3.3.5 | 同类评论合并 | 同文件同类问题去重 | 在同一文件中重复 5 次 `Math.random()` 模式 | 不产出 5 条重复评论，合并为 1~2 条 |
+| 3.3.6 | `max_review_comments: 0` | 不截断 | workflow 设置 `max_review_comments: 0` | 所有评论都展示，无截断提示 |
+
+### 验证代码 — 案例 3.3.1 ~ 3.3.5
+
+```typescript
+// quality-issues.ts — 混合各级别问题
+import { readFileSync } from 'fs'
+
+// ===== Critical 问题 =====
+export function login(username: string, password: string) {
+  const query = `SELECT * FROM users WHERE name='${username}' AND pwd='${password}'`
+  eval(query)  // SQL注入 + eval
+}
+
+export function renderHtml(userInput: string) {
+  document.innerHTML = userInput  // XSS
+}
+
+export function executeCommand(cmd: string) {
+  require('child_process').execSync(cmd)  // 命令注入
+}
+
+// ===== Major 问题 =====
+export async function fetchData(url: string) {
+  fetch(url)  // 忘记 await
+}
+
+export function divide(a: number, b: number) {
+  return a / b  // 未检查除零
+}
+
+export function parseConfig(json: string) {
+  return JSON.parse(json)  // 未 try-catch
+}
+
+// ===== Minor / Nit 问题 =====
+export function formatName(first: string, last: string) {
+  var fullName = first + ' ' + last  // var → const/let
+  return fullName
+}
+
+export function getRandomId() { return Math.random().toString(36).slice(2) }
+export function getRandomToken() { return Math.random().toString(36).slice(2) }
+export function getRandomKey() { return Math.random().toString(36).slice(2) }
+export function getRandomValue() { return Math.random().toString(36).slice(2) }
+export function getRandomHash() { return Math.random().toString(36).slice(2) }
+
+export function unusedImportDemo() {
+  const fs = readFileSync  // 未使用
+  return 'hello'
+}
+```
+
+**验证方式:**
+- 检查评论排列顺序：SQL 注入/XSS/命令注入（critical）在前
+- 检查 `Math.random` 系列 5 个函数是否被合并为 1~2 条评论
+- 统计最终评论数（应 ≤ 20）
+
+---
+
+## 3.4 Linter/SAST 集成（P0）
+
+| # | 场景 | 验证点 | 操作步骤 | 预期结果 |
+|---|------|--------|----------|----------|
+| 3.4.1 | ESLint 检测结果注入 | AI 评论引用 ESLint 规则 | 包含 ESLint 可检测问题（no-unused-vars、no-undef） | 评论中出现 "ESLint reports…" 或规则名 |
+| 3.4.2 | tsc 类型错误 | AI 评论引用 TypeScript 错误码 | 包含类型不匹配代码 | 评论中出现 TS 错误码如 `TS2345` |
+| 3.4.3 | Biome 检测 | AI 评论引用 Biome 规则 | 包含 Biome 可检测问题（如不安全的类型断言） | 评论中引用 Biome lint 规则 |
+| 3.4.4 | 工具归因卡片 | 评论底部有 "🧰 Tools" 段落 | 检查行级评论末尾 | 含 `🧰 Tools` + 列出参与分析的工具名 |
+| 3.4.5 | `enable_lint_tools: false` | 无 lint 相关内容 | workflow 设置 `enable_lint_tools: false` | 评论中无规则引用、无 Tools 卡片 |
+| 3.4.6 | 单独禁用某工具 | 该工具不运行 | 设置 `enable_eslint: false` | 无 ESLint 规则引用，但 tsc/Biome 仍有 |
+| 3.4.7 | Semgrep SAST 扫描 | 检出安全漏洞 | 设置 `enable_semgrep: true`，代码含注入/XSS | 评论中引用 Semgrep 规则 ID |
+
+### 验证代码 — 案例 3.4.1 ~ 3.4.3
+
+```typescript
+// lint-violations.ts — 触发多种 lint 工具
+import { readFileSync } from 'fs'
+
+// ESLint: no-unused-vars
+const unusedVariable = 42
+
+// ESLint: no-undef (if not tsconfig-configured)
+// tsc: TS2304 Cannot find name
+function callUndefined() {
+  return undeclaredFunction()
+}
+
+// tsc: TS2345 类型不匹配
+function expectNumber(n: number): number {
+  return n * 2
+}
+const result = expectNumber("hello" as any as number)
+
+// Biome: noExplicitAny
+export function unsafeAny(x: any): any {
+  return x.foo.bar.baz
+}
+
+// Biome: useConst
+export function shouldUseConst() {
+  let value = 'never reassigned'
+  return value
+}
+```
+
+### 验证代码 — 案例 3.4.7 (Semgrep)
+
+```typescript
+// security-semgrep.ts — Semgrep SAST 可检测的安全问题
+import express from 'express'
+import { execSync } from 'child_process'
+
+const app = express()
+
+// semgrep: javascript.express.security.audit.xss.mustache-escape
+app.get('/profile', (req, res) => {
+  res.send(`<h1>Welcome ${req.query.name}</h1>`)
+})
+
+// semgrep: javascript.lang.security.audit.dangerous-exec
+app.post('/run', (req, res) => {
+  const output = execSync(req.body.command)
+  res.json({ output: output.toString() })
+})
+```
+
+---
+
+## 3.5 AI 评论去重（P1）
+
+| # | 场景 | 验证点 | 操作步骤 | 预期结果 |
+|---|------|--------|----------|----------|
+| 3.5.1 | 同一 lint finding 多条评论合并 | 合并为一条 | 同一 lint 规则在连续多行违规 | 合并为一条评论覆盖多行 |
+| 3.5.2 | 不同 lint finding 不合并 | 各自保留 | 不同规则违反在相邻行 | 分别产出独立评论 |
+| 3.5.3 | 合并后行号范围扩大 | 覆盖所有相关行 | 检查评论的 startLine-endLine | 范围从第一个违规行到最后一个 |
+| 3.5.4 | 纯 AI 洞察精确行号去重 | 同行合并 | 无 lint 场景下 AI 对同一行产出多条评论 | 同行评论合并为一条 |
+
+### 验证代码 — 案例 3.5.1 ~ 3.5.3
+
+```typescript
+// dedup-scenarios.ts — 触发评论合并
+export function processItems(items: string[]) {
+  // 连续 5 行相同模式违规 → 应合并
+  var item1 = items[0]   // no-var
+  var item2 = items[1]   // no-var
+  var item3 = items[2]   // no-var
+  var item4 = items[3]   // no-var
+  var item5 = items[4]   // no-var
+
+  // 不同类型违规 → 不应合并
+  eval(item1)                           // no-eval (安全问题)
+  console.log(item2)                    // no-console (风格问题)
+  return item3 == item4 ? item5 : null  // eqeqeq (正确性问题)
+}
+```
+
+---
+
+## 3.6 Web 搜索与 Shell 执行（P2）
+
+| # | 场景 | 验证点 | 操作步骤 | 预期结果 |
+|---|------|--------|----------|----------|
+| 3.6.1 | Web 搜索验证 API 用法 | Analysis chain 含 `web_search` 步骤 | 代码使用最新/冷门 API | 摘要或评论中引用搜索结果 |
+| 3.6.2 | Shell 执行辅助分析 | Analysis chain 含 `shell` 步骤 | 代码有依赖版本相关问题 | Actions 日志有 shell 调用记录 |
+| 3.6.3 | `enable_web_search: false` | 无 web_search 步骤 | workflow 关闭 web search | Actions 日志无 `[web_search_debug]` |
+| 3.6.4 | `enable_shell: false` | 无 shell 步骤 | workflow 关闭 shell | Actions 日志无 shell 调用 |
+
+### 验证代码 — 案例 3.6.1
+
+```typescript
+// web-search-trigger.ts — 使用冷门/新 API 触发联网搜索
+import { experimental_useOptimistic } from 'react'
+
+export function PaymentForm() {
+  // 使用 Stripe Payment Element v3（假设为新发布 API）
+  const [optimistic, setOptimistic] = experimental_useOptimistic(null)
+  
+  // 使用 Web Crypto API 的较新方法
+  const key = crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt: new Uint8Array(16), iterations: 100000, hash: 'SHA-256' },
+    await crypto.subtle.importKey('raw', new TextEncoder().encode('password'), 'PBKDF2', false, ['deriveKey']),
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+```
+
+---
+
+## 综合端到端脚本
+
+```bash
+#!/bin/bash
+# setup-3-quality-control.sh — 创建包含多种质量问题的 PR
+set -e
+
+REPO_DIR="/Users/anton/Developer/CodesSentinels/ai-reviewer-test"
+BRANCH="test/tester3-quality-$(date +%m%d-%H%M)"
+TARGET="test/dev4"
+
+cd "$REPO_DIR"
+git fetch origin
+git checkout -b "$BRANCH" "origin/$TARGET"
+
+mkdir -p quality-tests
+
+# 写入测试文件
+cat > quality-tests/conversation-anchor.ts << 'EOF'
+export function processPayment(amount: number, userId: string) {
+  if (amount) {
+    const query = `UPDATE balance SET amount = ${amount} WHERE user = '${userId}'`
+    return executeQuery(query)
+  }
+}
+
+export function generateToken(): string {
+  return Math.random().toString(36).slice(2)
+}
+EOF
+
+cat > quality-tests/quality-issues.ts << 'EOF'
+import { readFileSync } from 'fs'
+
+export function login(username: string, password: string) {
+  const query = `SELECT * FROM users WHERE name='${username}' AND pwd='${password}'`
+  eval(query)
+}
+
+export function renderHtml(userInput: string) {
+  document.innerHTML = userInput
+}
+
+export function executeCommand(cmd: string) {
+  require('child_process').execSync(cmd)
+}
+
+export async function fetchData(url: string) {
+  fetch(url)
+}
+
+export function divide(a: number, b: number) {
+  return a / b
+}
+
+export function formatName(first: string, last: string) {
+  var fullName = first + ' ' + last
+  return fullName
+}
+
+export function getRandomId() { return Math.random().toString(36).slice(2) }
+export function getRandomToken() { return Math.random().toString(36).slice(2) }
+export function getRandomKey() { return Math.random().toString(36).slice(2) }
+export function getRandomValue() { return Math.random().toString(36).slice(2) }
+export function getRandomHash() { return Math.random().toString(36).slice(2) }
+EOF
+
+cat > quality-tests/lint-violations.ts << 'EOF'
+import { readFileSync } from 'fs'
+
+const unusedVariable = 42
+
+function callUndefined() {
+  return undeclaredFunction()
+}
+
+function expectNumber(n: number): number {
+  return n * 2
+}
+const result = expectNumber("hello" as any as number)
+
+export function unsafeAny(x: any): any {
+  return x.foo.bar.baz
+}
+
+export function shouldUseConst() {
+  let value = 'never reassigned'
+  return value
+}
+EOF
+
+cat > quality-tests/dedup-scenarios.ts << 'EOF'
+export function processItems(items: string[]) {
+  var item1 = items[0]
+  var item2 = items[1]
+  var item3 = items[2]
+  var item4 = items[3]
+  var item5 = items[4]
+
+  eval(item1)
+  console.log(item2)
+  return item3 == item4 ? item5 : null
+}
+EOF
+
+git add quality-tests/
+git commit -m "test: add quality control test files (tester 3)"
+git push origin "$BRANCH"
+
+echo ""
+echo "✅ 分支已推送: $BRANCH"
+echo ""
+echo "下一步:"
+echo "  1. 创建 PR: $BRANCH → $TARGET"
+echo "  2. 等 Bot 产出行级评论"
+echo "  3. 在评论 thread 中进行对话追问测试 (3.1)"
+echo "  4. 检查评论格式 (3.3) 和 lint 引用 (3.4)"
+```
+
+---
+
+## 测试结果记录模板
+
+### 3.1 对话式追问交互（P0）
+
+| # | 场景 | 结果 | 备注 |
+|---|------|------|------|
+| 3.1.1 | 行级评论追问 | ✅/❌/⚠️ | |
+| 3.1.2 | 续轮追问 | ✅/❌/⚠️ | |
+| 3.1.3 | 不带 @bot 不触发 | ✅/❌/⚠️ | |
+| 3.1.4 | Bot 自回复不循环 | ✅/❌/⚠️ | |
+| 3.1.5 | 引用文件完整 diff | ✅/❌/⚠️ | |
+| 3.1.6 | 引用 PR 摘要 | ✅/❌/⚠️ | |
+
+### 3.2 对话轮次与截断（P1）
+
+| # | 场景 | 结果 | 备注 |
+|---|------|------|------|
+| 3.2.1 | 10 轮限制 | ✅/❌/⚠️ | |
+| 3.2.2 | 长上下文截断 | ✅/❌/⚠️ | |
+| 3.2.3 | 截断保留最近 | ✅/❌/⚠️ | |
+| 3.2.4 | issue_comment 不支持 | ✅/❌/⚠️ | |
+
+### 3.3 噪音控制（P0）
+
+| # | 场景 | 结果 | 备注 |
+|---|------|------|------|
+| 3.3.1 | 严重级别徽标 | ✅/❌/⚠️ | |
+| 3.3.2 | 级别排序 | ✅/❌/⚠️ | |
+| 3.3.3 | 评论截断(20) | ✅/❌/⚠️ | |
+| 3.3.4 | 截断保留高优先级 | ✅/❌/⚠️ | |
+| 3.3.5 | 同类合并 | ✅/❌/⚠️ | |
+| 3.3.6 | 不截断(max=0) | ✅/❌/⚠️ | |
+
+### 3.4 Linter/SAST 集成（P0）
+
+| # | 场景 | 结果 | 备注 |
+|---|------|------|------|
+| 3.4.1 | ESLint 结果注入 | ✅/❌/⚠️ | |
+| 3.4.2 | tsc 类型错误 | ✅/❌/⚠️ | |
+| 3.4.3 | Biome 检测 | ✅/❌/⚠️ | |
+| 3.4.4 | 工具归因卡片 | ✅/❌/⚠️ | |
+| 3.4.5 | lint 总开关关闭 | ✅/❌/⚠️ | |
+| 3.4.6 | 单独禁用工具 | ✅/❌/⚠️ | |
+| 3.4.7 | Semgrep SAST | ✅/❌/⚠️ | |
+
+### 3.5 AI 评论去重（P1）
+
+| # | 场景 | 结果 | 备注 |
+|---|------|------|------|
+| 3.5.1 | 同 lint 合并 | ✅/❌/⚠️ | |
+| 3.5.2 | 不同 lint 不合并 | ✅/❌/⚠️ | |
+| 3.5.3 | 合并行号范围 | ✅/❌/⚠️ | |
+| 3.5.4 | 纯 AI 同行去重 | ✅/❌/⚠️ | |
+
+### 3.6 Web 搜索与 Shell（P2）
+
+| # | 场景 | 结果 | 备注 |
+|---|------|------|------|
+| 3.6.1 | Web 搜索触发 | ✅/❌/⚠️ | |
+| 3.6.2 | Shell 执行 | ✅/❌/⚠️ | |
+| 3.6.3 | 关闭 web search | ✅/❌/⚠️ | |
+| 3.6.4 | 关闭 shell | ✅/❌/⚠️ | |
+
+---
+
+## 关键提示
+
+1. **测试顺序**：先执行 3.3/3.4（噪音控制 + Lint），因为 Bot 需要先产出行级评论后才能进行 3.1（对话追问）
+2. **等待时间**：每次 PR 创建 / push 后需等待 1~3 分钟让 Bot 完成审查
+3. **Actions 日志**：3.2（轮次限制）、3.6（Web/Shell）需要查看 GitHub Actions 运行日志确认
+4. **配置切换**：3.3.6、3.4.5、3.4.6、3.6.3、3.6.4 需要临时修改 workflow 配置，测试后恢复
+5. **对话测试依赖**：3.1 和 3.2 依赖 Bot 先产出行级评论（由 3.3/3.4 的 PR 自动触发），建议在同一 PR 中先等审查完再开始追问


### PR DESCRIPTION
## Summary

新增测试人 3（对话交互与质量控制）的测试用例文档和流程图。

- `docs/tasks/tester-3-quality-control-testcases.md` — 27 个测试用例，覆盖 6 个模块
- `docs/tasks/tester-3-flow-diagrams.md` — 4 组 Mermaid 流程图，标注测试编号

## 用例分布

| 模块 | 用例数 | 优先级 |
|------|--------|--------|
| 3.1 对话追问 | 6 | P0 |
| 3.2 轮次截断 | 4 | P1 |
| 3.3 噪音控制 | 6 | P0 |
| 3.4 Lint/SAST | 7 | P0 |
| 3.5 评论去重 | 4 | P1 |
| 3.6 Web/Shell | 4 | P2 |

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)