### PR TITLE
feat: 定义平台无关 ExecutionContext（ARCH-001~ARCH-006）

### DIFF
--- a/__tests__/command-handler.test.ts
+++ b/__tests__/command-handler.test.ts
@@ -1,0 +1,262 @@
+/**
+ * command-handler.test.ts — handleCommentEvent() 回归测试（U4）
+ *
+ * command-handler.ts 在 ARCH-005/T5 完成了全量迁移（execCtx 取代直接
+ * import @actions/github），但此前没有任何专门测试覆盖过它。本文件补齐这块
+ * 覆盖，验证 execCtx 正确透传给 dispatchCommentEvent/codeReview，以及
+ * fallback_conversation 分支按 execCtx.eventKind 正确二选一（不误触发/不双发）。
+ * 对齐 docs/tasks/execution-context-design.md 第 9.2 节 U4 / TODO TEST-001。
+ */
+import {describe, expect, test, jest, beforeEach} from '@jest/globals'
+
+jest.mock('@actions/core', () => ({
+  info: jest.fn()
+}))
+
+const bootstrapState = {bootstrapCommands: jest.fn()}
+jest.mock('./../src/commands/bootstrap', () => ({
+  bootstrapCommands: (...a: any[]) => bootstrapState.bootstrapCommands(...a)
+}))
+
+const dispatcherState = {
+  dispatchCommentEvent: jest.fn<(...a: any[]) => Promise<any>>()
+}
+jest.mock('./../src/commands/dispatcher', () => ({
+  dispatchCommentEvent: (...a: any[]) => dispatcherState.dispatchCommentEvent(...a)
+}))
+
+const reviewState = {codeReview: jest.fn<(...a: any[]) => Promise<void>>()}
+jest.mock('./../src/review', () => ({
+  codeReview: (...a: any[]) => reviewState.codeReview(...a)
+}))
+
+const conversationState = {
+  handleConversation: jest.fn<(...a: any[]) => Promise<void>>(),
+  handleIssueConversation: jest.fn<(...a: any[]) => Promise<void>>()
+}
+jest.mock('./../src/conversation', () => ({
+  handleConversation: (...a: any[]) => conversationState.handleConversation(...a),
+  handleIssueConversation: (...a: any[]) =>
+    conversationState.handleIssueConversation(...a)
+}))
+
+import {handleCommentEvent} from '../src/command-handler'
+
+function makeExecCtx(overrides: Record<string, any> = {}): any {
+  return {
+    platform: 'github',
+    projectPath: 'octo/demo',
+    projectId: 'octo/demo',
+    changeRequestId: 42,
+    eventKind: 'comment_created',
+    actor: {login: 'alice', isBot: false},
+    baseSha: '',
+    headSha: '',
+    raw: {},
+    ...overrides
+  }
+}
+
+const stubOptions: any = {}
+const stubPrompts: any = {}
+const lightBot: any = {chat: jest.fn()}
+const heavyBot: any = {chat: jest.fn()}
+
+describe('handleCommentEvent()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'ignored', reason: 'x'})
+    reviewState.codeReview.mockResolvedValue(undefined)
+    conversationState.handleConversation.mockResolvedValue(undefined)
+    conversationState.handleIssueConversation.mockResolvedValue(undefined)
+  })
+
+  test('始终调用 bootstrapCommands()', async () => {
+    await handleCommentEvent({execCtx: makeExecCtx(), options: stubOptions, prompts: stubPrompts})
+    expect(bootstrapState.bootstrapCommands).toHaveBeenCalledTimes(1)
+  })
+
+  test('把 execCtx 和 options 透传给 dispatchCommentEvent，并提供 triggerReview 函数', async () => {
+    const execCtx = makeExecCtx()
+    await handleCommentEvent({execCtx, options: stubOptions, prompts: stubPrompts})
+
+    expect(dispatcherState.dispatchCommentEvent).toHaveBeenCalledTimes(1)
+    const arg = dispatcherState.dispatchCommentEvent.mock.calls[0][0] as any
+    expect(arg.execCtx).toBe(execCtx)
+    expect(arg.options).toBe(stubOptions)
+    expect(typeof arg.triggerReview).toBe('function')
+  })
+
+  test('triggerReview("incremental") 调用 codeReview，execCtx 作为首参，mode=incremental', async () => {
+    const execCtx = makeExecCtx()
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('incremental')
+      return {kind: 'executed', command: 'review', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx,
+      lightBot,
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(reviewState.codeReview).toHaveBeenCalledTimes(1)
+    const [ctxArg, lb, hb, opts, prompts, runOptions] = reviewState.codeReview.mock
+      .calls[0] as any[]
+    expect(ctxArg).toBe(execCtx)
+    expect(lb).toBe(lightBot)
+    expect(hb).toBe(heavyBot)
+    expect(opts).toBe(stubOptions)
+    expect(prompts).toBe(stubPrompts)
+    expect(runOptions).toEqual({mode: 'incremental', source: 'command', summaryOnly: false})
+  })
+
+  test('triggerReview("full") → mode=full, summaryOnly=false', async () => {
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('full')
+      return {kind: 'executed', command: 'full review', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx(),
+      lightBot,
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    const runOptions = reviewState.codeReview.mock.calls[0][5]
+    expect(runOptions).toEqual({mode: 'full', source: 'command', summaryOnly: false})
+  })
+
+  test('triggerReview("summary") → mode=full（非 incremental）, summaryOnly=true', async () => {
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('summary')
+      return {kind: 'executed', command: 'summary', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx(),
+      lightBot,
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    const runOptions = reviewState.codeReview.mock.calls[0][5]
+    expect(runOptions).toEqual({mode: 'full', source: 'command', summaryOnly: true})
+  })
+
+  test('triggerReview：lightBot/heavyBot 和 getReviewBots 均不可用时抛错，不调用 codeReview', async () => {
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await expect(deps.triggerReview('incremental')).rejects.toThrow(
+        'OpenAI bot is unavailable for review command'
+      )
+      return {kind: 'executed', command: 'review', ok: false}
+    })
+
+    await handleCommentEvent({execCtx: makeExecCtx(), options: stubOptions, prompts: stubPrompts})
+    expect(reviewState.codeReview).not.toHaveBeenCalled()
+  })
+
+  test('triggerReview：优先用直接传入的 lightBot/heavyBot，其次才用 getReviewBots()', async () => {
+    const getReviewBots = jest.fn(() => ({lightBot, heavyBot}))
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('incremental')
+      return {kind: 'executed', command: 'review', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx(),
+      lightBot,
+      heavyBot,
+      getReviewBots,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(getReviewBots).not.toHaveBeenCalled()
+    expect(reviewState.codeReview).toHaveBeenCalledTimes(1)
+  })
+
+  test('outcome.kind !== fallback_conversation → 不触发任何对话式追问', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({
+      kind: 'executed',
+      command: 'review',
+      ok: true
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx({eventKind: 'review_comment_created'}),
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation + eventKind=review_comment_created → 调用 handleConversation，不调用 handleIssueConversation', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+    const execCtx = makeExecCtx({eventKind: 'review_comment_created'})
+
+    await handleCommentEvent({execCtx, heavyBot, options: stubOptions, prompts: stubPrompts})
+
+    expect(conversationState.handleConversation).toHaveBeenCalledTimes(1)
+    expect(conversationState.handleConversation).toHaveBeenCalledWith(
+      execCtx,
+      heavyBot,
+      stubOptions,
+      stubPrompts
+    )
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation + eventKind=comment_created → 调用 handleIssueConversation，不调用 handleConversation', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+    const execCtx = makeExecCtx({eventKind: 'comment_created'})
+
+    await handleCommentEvent({execCtx, heavyBot, options: stubOptions, prompts: stubPrompts})
+
+    expect(conversationState.handleIssueConversation).toHaveBeenCalledTimes(1)
+    expect(conversationState.handleIssueConversation).toHaveBeenCalledWith(
+      execCtx,
+      heavyBot,
+      stubOptions,
+      stubPrompts
+    )
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation + 不支持的 eventKind（如 pr_opened）→ 两个对话处理器都不调用', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx({eventKind: 'pr_opened'}),
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation 但 heavyBot 和 getReviewBots 均不可用 → 静默跳过，不抛错', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+
+    await expect(
+      handleCommentEvent({
+        execCtx: makeExecCtx({eventKind: 'comment_created'}),
+        options: stubOptions,
+        prompts: stubPrompts
+      })
+    ).resolves.toBeUndefined()
+
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/execution-context-error.test.ts
+++ b/__tests__/execution-context-error.test.ts
@@ -1,0 +1,55 @@
+/**
+ * execution-context-error.test.ts — ExecutionContextError 分类断言（U3）
+ *
+ * 覆盖 ExecutionContextError 类本身的行为（构造参数正确赋值、name/instanceof），
+ * 以及 GitHub/GitLab 两个工厂函数分别在哪些 reason 下抛出该错误的矩阵验证。
+ *
+ * 注：ExecutionContextError.reason 的类型定义包含 4 种取值
+ * （missing_payload/malformed_payload/unknown_event/missing_required_field），
+ * 但当前两个工厂函数实际只会抛出其中 3 种——`malformed_payload` 目前没有任何
+ * 调用点使用（GitLab CLI 的 JSON.parse 失败发生在 gitlab-trigger.ts 里，在
+ * 调用 createGitLabExecutionContext 之前就已经处理掉，不会变成
+ * ExecutionContextError）。这是已知的、有意保留的预留分类，不是本测试的缺陷，
+ * 对齐设计文档 9.2 节 U3"三种 reason 分类断言"的原始措辞。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+describe('ExecutionContextError', () => {
+  test('构造函数正确赋值 message/platform/reason，name 固定为 ExecutionContextError', () => {
+    const e = new ExecutionContextError('boom', 'github', 'unknown_event')
+
+    expect(e.message).toBe('boom')
+    expect(e.platform).toBe('github')
+    expect(e.reason).toBe('unknown_event')
+    expect(e.name).toBe('ExecutionContextError')
+  })
+
+  test('是 Error 的实例，也是 ExecutionContextError 的实例', () => {
+    const e = new ExecutionContextError('boom', 'gitlab', 'missing_payload')
+    expect(e).toBeInstanceOf(Error)
+    expect(e).toBeInstanceOf(ExecutionContextError)
+  })
+
+  test.each([
+    {platform: 'github', reason: 'missing_payload'},
+    {platform: 'github', reason: 'unknown_event'},
+    {platform: 'github', reason: 'missing_required_field'},
+    {platform: 'gitlab', reason: 'missing_payload'},
+    {platform: 'gitlab', reason: 'unknown_event'},
+    {platform: 'gitlab', reason: 'missing_required_field'}
+  ] as const)(
+    '$platform 平台可以构造 reason=$reason 的错误，且字段可读',
+    ({platform, reason}) => {
+      const e = new ExecutionContextError(`${platform}/${reason} test`, platform, reason)
+      expect(e.platform).toBe(platform)
+      expect(e.reason).toBe(reason)
+    }
+  )
+
+  test('malformed_payload 是类型定义里预留但当前两个工厂函数均未使用的 reason（记录现状，非缺陷）', () => {
+    // 仍然能正常构造——只是没有任何生产代码路径会触发它
+    const e = new ExecutionContextError('reserved', 'github', 'malformed_payload')
+    expect(e.reason).toBe('malformed_payload')
+  })
+})

--- a/__tests__/execution-context.integration.test.ts
+++ b/__tests__/execution-context.integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * execution-context.integration.test.ts — main.ts → ExecutionContext →
+ * codeReview()/handleCommentEvent() 全链路集成测试（I1）
+ *
+ * 阶段零/二的既有测试都在链路的某一层做了 mock 隔断：
+ *   - main.characterization.test.ts：codeReview/handleCommentEvent 被 mock，
+ *     只验证 main.ts 的分发逻辑本身。
+ *   - review-execctx-consistency.test.ts（U5）：直接调用 codeReview()，
+ *     不经过 main.ts 的事件分发。
+ *   - command-dispatcher.test.ts：triggerReview 被 mock，不真正跑 codeReview。
+ *   - command-handler.test.ts（U4）：dispatchCommentEvent/codeReview 被 mock。
+ *
+ * 本文件是唯一一处让 main.ts（真实 run()）→ createGitHubExecutionContext
+ * （真实）→ command-handler/dispatcher（真实）→ codeReview（真实）全部串联、
+ * 只在最外层 I/O 边界（octokit/Bot/Commenter/文件系统）打桩的测试，验证这条
+ * "从 GitHub 事件到实际业务逻辑"的链路没有断点。
+ *
+ * 覆盖 I1 要求的 pull_request（自动审查）+ issue_comment（命令分发）两类事件；
+ * pull_request_review_comment 与 issue_comment 在 dispatcher.ts 里走几乎相同
+ * 的代码路径（差异只在如何取 PR number/comment），且已被 command-dispatcher.
+ * test.ts 和 main.characterization.test.ts 分别独立验证过，本文件不重复第三个
+ * 全链路场景，是刻意的范围取舍。
+ *
+ * 参考 docs/tasks/execution-context-design.md 第 9.3 节 I1。
+ */
+import {describe, expect, test, jest, beforeEach} from '@jest/globals'
+
+const coreState = {
+  getBooleanInput: jest.fn<(name: string) => boolean>(),
+  getMultilineInput: jest.fn<(...a: any[]) => string[]>().mockReturnValue([]),
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  setFailed: jest.fn()
+}
+// 数值型 input 必须给合法字符串——main.ts 把 getInput() 的结果直接传给 Options
+// 构造函数，空字符串会被 parseInt/parseFloat 成 NaN，导致 codeReview 内部的
+// maxFiles/token 预算判断全部失效（体现为"一个文件都不处理"）。
+const NUMERIC_INPUT_DEFAULTS: Record<string, string> = {
+  max_files: '0',
+  openai_model_temperature: '0.0',
+  openai_retries: '3',
+  openai_timeout_ms: '120000',
+  openai_concurrency_limit: '6',
+  github_concurrency_limit: '6',
+  max_dependency_files: '50',
+  max_review_comments: '20',
+  debug_resolve_inject_failures: '0'
+}
+const getInputMock = jest.fn<(name: string) => string>((name: string) => {
+  return NUMERIC_INPUT_DEFAULTS[name] ?? ''
+})
+jest.mock('@actions/core', () => ({
+  getInput: (...a: any[]) => getInputMock(...(a as [string])),
+  getBooleanInput: (...a: any[]) => coreState.getBooleanInput(...(a as [string])),
+  getMultilineInput: (...a: any[]) => coreState.getMultilineInput(...a),
+  info: (...a: any[]) => coreState.info(...a),
+  warning: (...a: any[]) => coreState.warning(...a),
+  error: (...a: any[]) => coreState.error(...a),
+  setFailed: (...a: any[]) => coreState.setFailed(...a)
+}))
+
+const mockContext: any = {
+  eventName: '',
+  actor: 'someone',
+  payload: {},
+  repo: {owner: 'octo', repo: 'demo'}
+}
+jest.mock('@actions/github', () => ({context: mockContext}))
+
+// main.ts 是 `new Bot(...)`（非 type-only），必须 mock 掉，否则会因缺少
+// OPENAI_API_KEY 在 createBots() 内部抛错，导致后续分支永远走不到。
+const botState = {chat: jest.fn<() => Promise<[string, Record<string, unknown>, unknown[]]>>()}
+jest.mock('../src/bot', () => ({
+  Bot: jest.fn().mockImplementation(() => ({chat: (...a: any[]) => botState.chat(...(a as []))})),
+  OpenAIOptions: jest.fn()
+}))
+
+const octokitState = {
+  compareCommits: jest.fn<(...a: any[]) => Promise<any>>(),
+  getContent: jest.fn<(...a: any[]) => Promise<any>>(),
+  pullsGet: jest.fn<(...a: any[]) => Promise<any>>(),
+  getCollaboratorPermissionLevel: jest.fn<(...a: any[]) => Promise<any>>(),
+  listComments: jest.fn<(...a: any[]) => Promise<any>>(),
+  createComment: jest.fn<(...a: any[]) => Promise<any>>(),
+  updateComment: jest.fn<(...a: any[]) => Promise<any>>(),
+  createReactionForIssueComment: jest.fn<(...a: any[]) => Promise<any>>(),
+  createReactionForPRComment: jest.fn<(...a: any[]) => Promise<any>>()
+}
+jest.mock('../src/octokit', () => ({
+  octokit: {
+    repos: {
+      compareCommits: (...a: any[]) => octokitState.compareCommits(...a),
+      getCollaboratorPermissionLevel: (...a: any[]) =>
+        octokitState.getCollaboratorPermissionLevel(...a)
+    },
+    pulls: {
+      get: (...a: any[]) => octokitState.pullsGet(...a)
+    },
+    issues: {
+      listComments: (...a: any[]) => octokitState.listComments(...a),
+      createComment: (...a: any[]) => octokitState.createComment(...a),
+      updateComment: (...a: any[]) => octokitState.updateComment(...a)
+    },
+    reactions: {
+      createForIssueComment: (...a: any[]) =>
+        octokitState.createReactionForIssueComment(...a),
+      createForPullRequestReviewComment: (...a: any[]) =>
+        octokitState.createReactionForPRComment(...a)
+    }
+  }
+}))
+
+const commenterState = {
+  getDescription: jest.fn((body: string) => body ?? ''),
+  findCommentWithTag: jest.fn<() => Promise<any>>().mockResolvedValue(null),
+  getAllCommitIds: jest.fn<() => Promise<any[]>>().mockResolvedValue([]),
+  getHighestReviewedCommitId: jest.fn().mockReturnValue(''),
+  getReviewedCommitIds: jest.fn().mockReturnValue([]),
+  getReviewedCommitIdsBlock: jest.fn().mockReturnValue(''),
+  getRawSummary: jest.fn().mockReturnValue(''),
+  getShortSummary: jest.fn().mockReturnValue(''),
+  addInProgressStatus: jest.fn().mockReturnValue('IN_PROGRESS'),
+  comment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  updateDescription: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  submitReview: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  addReviewedCommitId: jest.fn().mockReturnValue('<!-- reviewed-commit-ids -->'),
+  bufferReviewComment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  listReviewComments: jest.fn<() => Promise<any[]>>().mockResolvedValue([])
+}
+jest.mock('../src/commenter', () => ({
+  Commenter: jest.fn().mockImplementation(() => commenterState),
+  COMMENT_TAG: '<!-- bot-comment -->',
+  COMMENT_REPLY_TAG: '<!-- bot-reply -->',
+  RAW_SUMMARY_START_TAG: '<!-- raw-summary-start -->',
+  RAW_SUMMARY_END_TAG: '<!-- raw-summary-end -->',
+  SHORT_SUMMARY_START_TAG: '<!-- short-summary-start -->',
+  SHORT_SUMMARY_END_TAG: '<!-- short-summary-end -->',
+  SUMMARIZE_TAG: '<!-- summarize -->'
+}))
+
+jest.mock('../src/tokenizer', () => ({getTokenCount: () => 0}))
+jest.mock('../src/github/review-thread', () => ({
+  fetchThreadStatusMap: jest.fn<() => Promise<Map<string, boolean>>>().mockResolvedValue(new Map())
+}))
+
+function makePullRequestPayload(overrides: Record<string, any> = {}): any {
+  return {
+    number: 42,
+    title: 'Integration test PR',
+    body: 'body',
+    base: {sha: 'base-sha-0001'},
+    head: {sha: 'head-sha-0001'},
+    ...overrides
+  }
+}
+
+describe('I1: main.ts → ExecutionContext → codeReview/handleCommentEvent 全链路', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.GITHUB_EVENT_NAME
+    coreState.getBooleanInput.mockReturnValue(false)
+    coreState.getMultilineInput.mockReturnValue([])
+    getInputMock.mockImplementation((name: string) => NUMERIC_INPUT_DEFAULTS[name] ?? '')
+    botState.chat.mockResolvedValue(['[TRIAGE]: APPROVED\nLGTM', {}, []])
+
+    mockContext.actor = 'someone'
+    mockContext.payload = {}
+
+    commenterState.getDescription.mockImplementation((body: string) => body ?? '')
+    commenterState.findCommentWithTag.mockResolvedValue(null)
+    commenterState.getAllCommitIds.mockResolvedValue([])
+    commenterState.addInProgressStatus.mockReturnValue('IN_PROGRESS')
+    commenterState.addReviewedCommitId.mockReturnValue('<!-- reviewed-commit-ids -->')
+
+    octokitState.compareCommits.mockResolvedValue({
+      data: {
+        files: [
+          {
+            filename: 'src/foo.ts',
+            status: 'modified',
+            patch: '@@ -1,3 +1,4 @@\n line1\n line2\n+added line\n line3'
+          }
+        ],
+        commits: [{sha: 'head-sha-0001'}]
+      }
+    })
+    octokitState.getContent.mockResolvedValue({
+      data: {type: 'file', content: Buffer.from('line1\nline2\nline3').toString('base64')}
+    })
+  })
+
+  async function runMain(): Promise<void> {
+    jest.resetModules()
+    await import('../src/main')
+    await new Promise(resolve => setImmediate(resolve))
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  test('pull_request(opened) → 真实 codeReview 跑完全流程，最终发布带 SUMMARIZE_TAG 的摘要评论', async () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.eventName = 'pull_request'
+    mockContext.payload = {action: 'opened', pull_request: makePullRequestPayload()}
+
+    await runMain()
+
+    // in-progress 状态 + 最终摘要，两次 comment 调用，均带 SUMMARIZE_TAG + replace
+    expect(commenterState.comment).toHaveBeenCalledTimes(2)
+    for (const call of commenterState.comment.mock.calls) {
+      expect(call[1]).toBe('<!-- summarize -->')
+      expect(call[2]).toBe('replace')
+    }
+    // 证明真的走到了 diff 获取这一步（而不是在事件分发层就被吞掉）
+    expect(octokitState.compareCommits).toHaveBeenCalled()
+    expect(coreState.setFailed).not.toHaveBeenCalled()
+  })
+
+  test('issue_comment("@ai-reviewer help") → 真实 dispatcher 路由到 help handler，通过 octokit 发布回复', async () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.eventName = 'issue_comment'
+    mockContext.payload = {
+      action: 'created',
+      issue: {number: 42, pull_request: {}},
+      comment: {
+        id: 9001,
+        body: '@ai-reviewer help',
+        user: {login: 'alice', type: 'User'}
+      }
+    }
+    octokitState.getCollaboratorPermissionLevel.mockResolvedValue({
+      data: {permission: 'read'} // help 命令只需 Reporter/read 级别权限
+    })
+    octokitState.listComments.mockResolvedValue({data: []})
+    octokitState.createComment.mockResolvedValue({data: {id: 5555}})
+    octokitState.createReactionForIssueComment.mockResolvedValue({data: {id: 1}})
+
+    await runMain()
+
+    // help 命令走顶层 issue comment 回复（issues.createComment），不需要 codeReview/Bot
+    expect(octokitState.createComment).toHaveBeenCalled()
+    const [callArgs] = octokitState.createComment.mock.calls[0] as any[]
+    expect(callArgs.owner).toBe('octo')
+    expect(callArgs.repo).toBe('demo')
+    expect(callArgs.issue_number).toBe(42)
+    expect(coreState.setFailed).not.toHaveBeenCalled()
+    // help 命令不需要模型，Bot 不应被调用
+    expect(botState.chat).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/fixtures/gitlab-malformed.json
+++ b/__tests__/fixtures/gitlab-malformed.json
@@ -1,0 +1,13 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 9003,
+    "title": "Missing iid and source/target project ids"
+  }
+}

--- a/__tests__/fixtures/gitlab-mr-hook-fork.json
+++ b/__tests__/fixtures/gitlab-mr-hook-fork.json
@@ -1,0 +1,23 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "bob", "name": "Bob"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9002,
+    "iid": 8,
+    "title": "Fork contribution",
+    "source_branch": "feat/from-fork",
+    "target_branch": "main",
+    "source_project_id": 99,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "open",
+    "last_commit": {"id": "head-sha-fork-0001"}
+  },
+  "changes": {}
+}

--- a/__tests__/fixtures/gitlab-mr-hook-open.json
+++ b/__tests__/fixtures/gitlab-mr-hook-open.json
@@ -1,0 +1,23 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "open",
+    "last_commit": {"id": "head-sha-0001"}
+  },
+  "changes": {}
+}

--- a/__tests__/fixtures/gitlab-mr-hook-update-meta.json
+++ b/__tests__/fixtures/gitlab-mr-hook-update-meta.json
@@ -1,0 +1,32 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures (renamed)",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "update",
+    "last_commit": {"id": "head-sha-0001"}
+  },
+  "changes": {
+    "title": {
+      "previous": "Add characterization fixtures",
+      "current": "Add characterization fixtures (renamed)"
+    },
+    "labels": {
+      "previous": [],
+      "current": [{"title": "needs-review"}]
+    }
+  }
+}

--- a/__tests__/fixtures/gitlab-mr-hook-update-sha.json
+++ b/__tests__/fixtures/gitlab-mr-hook-update-sha.json
@@ -1,0 +1,29 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "update",
+    "oldrev": "head-sha-0001",
+    "last_commit": {"id": "head-sha-0002"}
+  },
+  "changes": {
+    "last_commit": {
+      "previous": {"id": "head-sha-0001"},
+      "current": {"id": "head-sha-0002"}
+    }
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-discussion.json
+++ b/__tests__/fixtures/gitlab-note-hook-discussion.json
@@ -1,0 +1,22 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5002,
+    "note": "@ai-reviewer 这里为什么这样写？",
+    "noteable_type": "MergeRequest",
+    "action": "create",
+    "discussion_id": "abc123discussionid"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-non-create.json
+++ b/__tests__/fixtures/gitlab-note-hook-non-create.json
@@ -1,0 +1,21 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5001,
+    "note": "@ai-reviewer review (edited)",
+    "noteable_type": "MergeRequest",
+    "action": "update"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-toplevel.json
+++ b/__tests__/fixtures/gitlab-note-hook-toplevel.json
@@ -1,0 +1,21 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5001,
+    "note": "@ai-reviewer review",
+    "noteable_type": "MergeRequest",
+    "action": "create"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-unknown-event.json
+++ b/__tests__/fixtures/gitlab-unknown-event.json
@@ -1,0 +1,12 @@
+{
+  "object_kind": "pipeline",
+  "event_type": "pipeline",
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 12345,
+    "status": "success"
+  }
+}

--- a/__tests__/github-execution-context.test.ts
+++ b/__tests__/github-execution-context.test.ts
@@ -1,0 +1,194 @@
+/**
+ * github-execution-context.test.ts — createGitHubExecutionContext() 单元测试（U1）
+ *
+ * 覆盖 4 类 GitHub 事件（PR 开启/更新/重开/元数据更新）+ 2 类评论事件
+ * （issue_comment/pull_request_review_comment）+ 缺字段 fail-closed 场景。
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U1。
+ */
+import {describe, expect, test, beforeEach, jest} from '@jest/globals'
+
+const mockContext: any = {
+  eventName: '',
+  actor: 'octocat',
+  payload: {},
+  repo: {owner: 'octo', repo: 'demo'}
+}
+jest.mock('@actions/github', () => ({context: mockContext}))
+
+import {createGitHubExecutionContext} from '../src/platform/github-execution-context'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+/** 捕获 fn 抛出的异常并返回，未抛出时让测试失败（避免依赖非标准全局 fail()） */
+function getThrownError(fn: () => unknown): unknown {
+  try {
+    fn()
+  } catch (e) {
+    return e
+  }
+  throw new Error('Expected function to throw, but it did not')
+}
+
+function makePr(overrides: Record<string, any> = {}): any {
+  return {
+    number: 42,
+    base: {sha: 'base-sha-0001'},
+    head: {sha: 'head-sha-0001'},
+    ...overrides
+  }
+}
+
+describe('createGitHubExecutionContext()', () => {
+  beforeEach(() => {
+    delete process.env.GITHUB_EVENT_NAME
+    mockContext.eventName = ''
+    mockContext.actor = 'octocat'
+    mockContext.payload = {}
+    mockContext.repo = {owner: 'octo', repo: 'demo'}
+  })
+
+  test('GITHUB_EVENT_NAME 未设置 → ExecutionContextError(missing_payload)', () => {
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).platform).toBe('github')
+    expect((e as ExecutionContextError).reason).toBe('missing_payload')
+  })
+
+  test('不支持的事件类型（如 push）→ ExecutionContextError(unknown_event)', () => {
+    process.env.GITHUB_EVENT_NAME = 'push'
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('unknown_event')
+    expect((e as ExecutionContextError).message).toContain('push')
+  })
+
+  test('pull_request action=opened → eventKind=pr_opened，字段映射正确', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'opened', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+
+    expect(execCtx.platform).toBe('github')
+    expect(execCtx.eventKind).toBe('pr_opened')
+    expect(execCtx.projectPath).toBe('octo/demo')
+    expect(execCtx.projectId).toBe('octo/demo')
+    expect(execCtx.changeRequestId).toBe(42)
+    expect(execCtx.baseSha).toBe('base-sha-0001')
+    expect(execCtx.headSha).toBe('head-sha-0001')
+    expect(execCtx.actor).toEqual({login: 'octocat', isBot: false})
+    expect(execCtx.comment).toBeUndefined()
+    expect(execCtx.raw).toBe(mockContext.payload)
+  })
+
+  test('pull_request_target action=synchronize → eventKind=pr_synchronize', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request_target'
+    mockContext.payload = {action: 'synchronize', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.eventKind).toBe('pr_synchronize')
+  })
+
+  test('pull_request action=reopened → eventKind=pr_reopened', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'reopened', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.eventKind).toBe('pr_reopened')
+  })
+
+  test('pull_request action=labeled（其它元数据更新）→ eventKind=metadata_updated', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'labeled', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.eventKind).toBe('metadata_updated')
+  })
+
+  test('pull_request 事件缺少 pull_request 字段 → ExecutionContextError(missing_required_field)', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'opened'}
+
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('issue_comment → eventKind=comment_created，comment.kind=top_level', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {
+      action: 'created',
+      issue: {number: 42},
+      comment: {id: 9001, node_id: 'IC_xxx', user: {login: 'alice'}}
+    }
+
+    const execCtx = createGitHubExecutionContext()
+
+    expect(execCtx.eventKind).toBe('comment_created')
+    expect(execCtx.changeRequestId).toBe(42)
+    expect(execCtx.baseSha).toBe('')
+    expect(execCtx.headSha).toBe('')
+    expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
+    expect(execCtx.comment).toEqual({
+      kind: 'top_level',
+      id: 9001,
+      threadId: 'IC_xxx'
+    })
+  })
+
+  test('pull_request_review_comment → eventKind=review_comment_created，comment.kind=review_thread', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request_review_comment'
+    mockContext.payload = {
+      action: 'created',
+      pull_request: {number: 42},
+      comment: {id: 9002, node_id: 'PRRC_xxx', user: {login: 'bob'}}
+    }
+
+    const execCtx = createGitHubExecutionContext()
+
+    expect(execCtx.eventKind).toBe('review_comment_created')
+    expect(execCtx.changeRequestId).toBe(42)
+    expect(execCtx.comment).toEqual({
+      kind: 'review_thread',
+      id: 9002,
+      threadId: 'PRRC_xxx'
+    })
+  })
+
+  test('评论事件缺少 comment 字段 → ExecutionContextError(missing_required_field)', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {action: 'created', issue: {number: 42}}
+
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('评论事件缺少 PR number（issue/pull_request 均为空） → ExecutionContextError(missing_required_field)', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {action: 'created', comment: {id: 1, user: {}}}
+
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('bot 评论者 login 以 [bot] 结尾 → actor.isBot=true', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {
+      action: 'created',
+      issue: {number: 42},
+      comment: {id: 1, user: {login: 'github-actions[bot]'}}
+    }
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.actor).toEqual({login: 'github-actions[bot]', isBot: true})
+  })
+
+  test('pull_request* 事件的 actor 来自 context.actor（bot 后缀同样识别）', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.actor = 'dependabot[bot]'
+    mockContext.payload = {action: 'opened', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.actor).toEqual({login: 'dependabot[bot]', isBot: true})
+  })
+})

--- a/__tests__/gitlab-execution-context.integration.test.ts
+++ b/__tests__/gitlab-execution-context.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * gitlab-execution-context.integration.test.ts — GitLab payload 字段完整性验证（I2）
+ *
+ * U2（gitlab-execution-context.test.ts）已经用同一批 fixture 做了逐场景的
+ * 单元测试（每个用例只挑关键字段断言、验证特定分支行为）。本文件换一个角度：
+ * 对全部 9 个共享 fixture 做一次性、完整字段快照比对——确保
+ * createGitLabExecutionContext 产出的 ExecutionContext 对象里，
+ * ExecutionContext 类型定义要求的每一个字段（platform/projectPath/projectId/
+ * changeRequestId/eventKind/actor/baseSha/headSha/comment?/raw）在每个成功
+ * 场景下都被正确、完整地填充，而不只是抽查过的那几个字段。
+ *
+ * 不接真实 GitLab（trigger CLI 尚未存在，见 EVENT-001~005），只用文档里
+ * 整理的 payload 结构手工构造/复用的 fixture。
+ *
+ * 参考 docs/tasks/execution-context-design.md 第 9.3 节 I2。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrUpdateSha from './fixtures/gitlab-mr-hook-update-sha.json'
+import mrUpdateMeta from './fixtures/gitlab-mr-hook-update-meta.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
+import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import unknownEvent from './fixtures/gitlab-unknown-event.json'
+import malformed from './fixtures/gitlab-malformed.json'
+
+const REQUIRED_FIELDS = [
+  'platform',
+  'projectPath',
+  'projectId',
+  'changeRequestId',
+  'eventKind',
+  'actor',
+  'baseSha',
+  'headSha',
+  'raw'
+] as const
+
+describe('I2: GitLab fixture 全字段完整性快照', () => {
+  test('MR open（gitlab-mr-hook-open.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(mrOpen)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'pr_opened',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      raw: mrOpen
+    })
+  })
+
+  test('MR update+SHA变化（gitlab-mr-hook-update-sha.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateSha)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'pr_synchronize',
+      actor: {login: 'alice', isBot: false},
+      baseSha: 'head-sha-0001',
+      headSha: 'head-sha-0002',
+      raw: mrUpdateSha
+    })
+  })
+
+  test('MR update+仅元数据（gitlab-mr-hook-update-meta.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateMeta)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'metadata_updated',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      raw: mrUpdateMeta
+    })
+  })
+
+  test('fork MR（gitlab-mr-hook-fork.json）→ 完整字段快照，projectPath/Id 取自 target project（顶层 project 字段）', () => {
+    const execCtx = createGitLabExecutionContext(mrFork)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 8,
+      eventKind: 'pr_opened',
+      actor: {login: 'bob', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-fork-0001',
+      raw: mrFork
+    })
+  })
+
+  test('Note create 顶层（gitlab-note-hook-toplevel.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(noteToplevel)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'comment_created',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      comment: {kind: 'top_level', id: 5001, threadId: undefined},
+      raw: noteToplevel
+    })
+  })
+
+  test('Note create discussion 回复（gitlab-note-hook-discussion.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(noteDiscussion)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'review_comment_created',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      comment: {kind: 'review_thread', id: 5002, threadId: 'abc123discussionid'},
+      raw: noteDiscussion
+    })
+  })
+
+  test.each([
+    {label: '未知 object_kind', fixture: unknownEvent, expectedReason: 'unknown_event'},
+    {
+      label: '缺少 iid/source-target project',
+      fixture: malformed,
+      expectedReason: 'missing_required_field'
+    },
+    {
+      label: 'note action != create',
+      fixture: noteNonCreate,
+      expectedReason: 'missing_required_field'
+    }
+  ] as const)('$label → 不产出 ExecutionContext，reason=$expectedReason', ({fixture, expectedReason}) => {
+    expect(() => createGitLabExecutionContext(fixture)).toThrow(ExecutionContextError)
+    try {
+      createGitLabExecutionContext(fixture)
+    } catch (e) {
+      expect((e as ExecutionContextError).reason).toBe(expectedReason)
+    }
+  })
+
+  test('全部 6 个成功场景的 ExecutionContext 都包含类型定义要求的全部必需字段', () => {
+    const successfulFixtures = [
+      mrOpen,
+      mrUpdateSha,
+      mrUpdateMeta,
+      mrFork,
+      noteToplevel,
+      noteDiscussion
+    ]
+    for (const fixture of successfulFixtures) {
+      const execCtx = createGitLabExecutionContext(fixture)
+      for (const field of REQUIRED_FIELDS) {
+        expect(execCtx).toHaveProperty(field)
+        expect((execCtx as any)[field]).not.toBeUndefined()
+      }
+    }
+  })
+})

--- a/__tests__/gitlab-execution-context.test.ts
+++ b/__tests__/gitlab-execution-context.test.ts
@@ -1,0 +1,160 @@
+/**
+ * gitlab-execution-context.test.ts — createGitLabExecutionContext() 单元测试（U2）
+ *
+ * 覆盖 MR open/reopen/update(HEAD变化)/update(仅元数据) + Note
+ * create(top-level)/create(discussion回复)/非 create 动作/未知 object_kind，
+ * 复用 __tests__/fixtures/ 下的共享 GitLab payload 样例（阶段一 G4 产出）。
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U2。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrUpdateSha from './fixtures/gitlab-mr-hook-update-sha.json'
+import mrUpdateMeta from './fixtures/gitlab-mr-hook-update-meta.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
+import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import unknownEvent from './fixtures/gitlab-unknown-event.json'
+import malformed from './fixtures/gitlab-malformed.json'
+
+/** 捕获 fn 抛出的异常并返回，未抛出时让测试失败（避免依赖非标准全局 fail()） */
+function getThrownError(fn: () => unknown): unknown {
+  try {
+    fn()
+  } catch (e) {
+    return e
+  }
+  throw new Error('Expected function to throw, but it did not')
+}
+
+describe('createGitLabExecutionContext()', () => {
+  test('payload 为 null → ExecutionContextError(missing_payload)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(null))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).platform).toBe('gitlab')
+    expect((e as ExecutionContextError).reason).toBe('missing_payload')
+  })
+
+  test('payload 非对象（字符串）→ ExecutionContextError(missing_payload)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext('not-an-object'))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_payload')
+  })
+
+  test('未知 object_kind（如 pipeline）→ ExecutionContextError(unknown_event)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(unknownEvent))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('unknown_event')
+  })
+
+  test('MR open → eventKind=pr_opened，字段映射正确', () => {
+    const execCtx = createGitLabExecutionContext(mrOpen)
+
+    expect(execCtx.platform).toBe('gitlab')
+    expect(execCtx.eventKind).toBe('pr_opened')
+    expect(execCtx.projectPath).toBe('octo/demo')
+    expect(execCtx.projectId).toBe('42')
+    expect(execCtx.changeRequestId).toBe(7)
+    expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
+    expect(execCtx.headSha).toBe('head-sha-0001')
+    expect(execCtx.comment).toBeUndefined()
+  })
+
+  test('MR update 且 changes.last_commit 存在 → eventKind=pr_synchronize', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateSha)
+
+    expect(execCtx.eventKind).toBe('pr_synchronize')
+    expect(execCtx.headSha).toBe('head-sha-0002')
+    expect(execCtx.baseSha).toBe('head-sha-0001') // oldrev
+  })
+
+  test('MR update 且 changes 只含 title/labels → eventKind=metadata_updated', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateMeta)
+    expect(execCtx.eventKind).toBe('metadata_updated')
+  })
+
+  test('MR reopen → eventKind=pr_reopened', () => {
+    const reopenPayload = {
+      ...mrOpen,
+      object_attributes: {...(mrOpen as any).object_attributes, action: 'reopen'}
+    }
+    const execCtx = createGitLabExecutionContext(reopenPayload)
+    expect(execCtx.eventKind).toBe('pr_reopened')
+  })
+
+  test('MR 缺少 object_attributes.iid → ExecutionContextError(missing_required_field)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(malformed))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('fork MR（source_project_id != target_project_id）→ 工厂函数本身不做 fork 拒绝，仍正常构造', () => {
+    // ARCH-004 明确不实现 EVENT-010（fork 拒绝）；这里确认工厂函数没有意外提前实现该逻辑
+    const execCtx = createGitLabExecutionContext(mrFork)
+    expect(execCtx.eventKind).toBe('pr_opened')
+    expect(execCtx.changeRequestId).toBe(8)
+  })
+
+  test('Note create（顶层）→ eventKind=comment_created，comment.kind=top_level', () => {
+    const execCtx = createGitLabExecutionContext(noteToplevel)
+
+    expect(execCtx.platform).toBe('gitlab')
+    expect(execCtx.eventKind).toBe('comment_created')
+    expect(execCtx.changeRequestId).toBe(7)
+    expect(execCtx.headSha).toBe('head-sha-0001') // merge_request.diff_head_sha
+    expect(execCtx.baseSha).toBe('')
+    expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
+    expect(execCtx.comment).toEqual({kind: 'top_level', id: 5001, threadId: undefined})
+  })
+
+  test('Note create（discussion 回复）→ eventKind=review_comment_created，comment.kind=review_thread', () => {
+    const execCtx = createGitLabExecutionContext(noteDiscussion)
+
+    expect(execCtx.eventKind).toBe('review_comment_created')
+    expect(execCtx.comment).toEqual({
+      kind: 'review_thread',
+      id: 5002,
+      threadId: 'abc123discussionid'
+    })
+  })
+
+  test('Note action != create → ExecutionContextError(missing_required_field)（已知缺口，见 issue #66：应优雅跳过而非 fail closed，本任务不修复）', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(noteNonCreate))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('Note 缺少 merge_request.iid → ExecutionContextError(missing_required_field)', () => {
+    const payload = {
+      object_kind: 'note',
+      user: {username: 'alice'},
+      project: {id: 42, path_with_namespace: 'octo/demo'},
+      object_attributes: {id: 5001, action: 'create', noteable_type: 'MergeRequest'}
+      // merge_request 字段整个缺失
+    }
+    const e = getThrownError(() => createGitLabExecutionContext(payload))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('Note noteable_type 不是 MergeRequest → ExecutionContextError(unknown_event)', () => {
+    const payload = {
+      object_kind: 'note',
+      user: {username: 'alice'},
+      project: {id: 42, path_with_namespace: 'octo/demo'},
+      object_attributes: {id: 5001, action: 'create', noteable_type: 'Issue'},
+      merge_request: {iid: 7}
+    }
+    const e = getThrownError(() => createGitLabExecutionContext(payload))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('unknown_event')
+  })
+
+  test('isBot 恒为 false（GitLab MVP 用个人 PAT，无天然 bot 标记，见 EVENT-018）', () => {
+    const execCtx = createGitLabExecutionContext(mrOpen)
+    expect(execCtx.actor.isBot).toBe(false)
+  })
+})

--- a/__tests__/review-execctx-consistency.test.ts
+++ b/__tests__/review-execctx-consistency.test.ts
@@ -1,0 +1,261 @@
+/**
+ * review-execctx-consistency.test.ts — review.ts 双轨一致性断言（U5）
+ *
+ * review.ts 的 codeReview() 在 T7 新增了 execCtx 首参数，但内部仍以模块级
+ * `context`/`repo`（`@actions/github`）为主要数据源（dual-track 过渡态，
+ * 见设计文档 6.3 节）。唯二真正读取 execCtx 的地方是 Phase 0 依赖分析调用
+ * getRepoFileTree()/analyzeDependencies() 时的 `execCtx.headSha || context.
+ * payload.pull_request.head.sha` 回退表达式。本测试验证：
+ *   1. 正常场景下 execCtx（由 createGitHubExecutionContext() 真实构造）与
+ *      context 两条数据源对同一事件算出的 headSha 一致；
+ *   2. execCtx.headSha 为空（评论触发场景）时，回退表达式正确退回到
+ *      context.payload.pull_request.head.sha，不会传出 undefined/空值。
+ *
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U5。
+ */
+import {describe, expect, test, jest, beforeEach} from '@jest/globals'
+
+jest.mock('@actions/core', () => ({
+  getInput: jest.fn().mockReturnValue(''),
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn()
+}))
+
+const mockContext: any = {
+  eventName: 'pull_request',
+  actor: 'someone',
+  payload: {},
+  repo: {owner: 'octo', repo: 'demo'}
+}
+jest.mock('@actions/github', () => ({context: mockContext}))
+
+const octokitState = {
+  compareCommits: jest.fn<(...a: any[]) => Promise<any>>(),
+  getContent: jest.fn<(...a: any[]) => Promise<any>>(),
+  pullsGet: jest.fn<(...a: any[]) => Promise<any>>()
+}
+jest.mock('../src/octokit', () => ({
+  octokit: {
+    repos: {
+      compareCommits: (...a: any[]) => octokitState.compareCommits(...a),
+      getContent: (...a: any[]) => octokitState.getContent(...a)
+    },
+    pulls: {
+      get: (...a: any[]) => octokitState.pullsGet(...a)
+    }
+  }
+}))
+
+const commenterState = {
+  getDescription: jest.fn((body: string) => body ?? ''),
+  findCommentWithTag: jest.fn<() => Promise<any>>().mockResolvedValue(null),
+  getAllCommitIds: jest.fn<() => Promise<any[]>>().mockResolvedValue([]),
+  getHighestReviewedCommitId: jest.fn().mockReturnValue(''),
+  getReviewedCommitIds: jest.fn().mockReturnValue([]),
+  getReviewedCommitIdsBlock: jest.fn().mockReturnValue(''),
+  getRawSummary: jest.fn().mockReturnValue(''),
+  getShortSummary: jest.fn().mockReturnValue(''),
+  addInProgressStatus: jest.fn().mockReturnValue('IN_PROGRESS'),
+  comment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  updateDescription: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  submitReview: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  addReviewedCommitId: jest.fn().mockReturnValue('<!-- reviewed-commit-ids -->'),
+  bufferReviewComment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  listReviewComments: jest.fn<() => Promise<any[]>>().mockResolvedValue([]),
+  getCommentChainsWithinRange: jest.fn<(...a: any[]) => Promise<string>>().mockResolvedValue('')
+}
+jest.mock('../src/commenter', () => ({
+  Commenter: jest.fn().mockImplementation(() => commenterState),
+  COMMENT_TAG: '<!-- bot-comment -->',
+  COMMENT_REPLY_TAG: '<!-- bot-reply -->',
+  RAW_SUMMARY_START_TAG: '<!-- raw-summary-start -->',
+  RAW_SUMMARY_END_TAG: '<!-- raw-summary-end -->',
+  SHORT_SUMMARY_START_TAG: '<!-- short-summary-start -->',
+  SHORT_SUMMARY_END_TAG: '<!-- short-summary-end -->',
+  SUMMARIZE_TAG: '<!-- summarize -->'
+}))
+
+jest.mock('../src/tokenizer', () => ({getTokenCount: () => 0}))
+
+jest.mock('../src/github/review-thread', () => ({
+  fetchThreadStatusMap: jest.fn<() => Promise<Map<string, boolean>>>().mockResolvedValue(new Map())
+}))
+
+const repoTreeState = {
+  getRepoFileTree: jest.fn<(...a: any[]) => Promise<string[]>>().mockResolvedValue([])
+}
+jest.mock('../src/repo-tree', () => ({
+  getRepoFileTree: (...a: any[]) => repoTreeState.getRepoFileTree(...a)
+}))
+
+const dependencyAnalyzerState = {
+  analyzeDependencies: jest
+    .fn<(...a: any[]) => Promise<any>>()
+    .mockResolvedValue({fileAnalyses: new Map()})
+}
+jest.mock('../src/dependency-analyzer', () => ({
+  analyzeDependencies: (...a: any[]) => dependencyAnalyzerState.analyzeDependencies(...a),
+  formatCrossFileContext: jest.fn().mockReturnValue(''),
+  formatDependencySummary: jest.fn().mockReturnValue('')
+}))
+
+import {codeReview} from '../src/review'
+import {createGitHubExecutionContext} from '../src/platform/github-execution-context'
+import {Options} from '../src/options'
+import {Prompts} from '../src/prompts'
+
+function makeOptions(): Options {
+  return new Options(
+    false, // debug
+    false, // disableReview
+    true, // disableReleaseNotes
+    '0', // maxFiles
+    false, // reviewSimpleChanges
+    false, // reviewCommentLGTM
+    null, // pathFilters
+    '', // systemMessage
+    'gpt-5.4-nano',
+    'gpt-5.4-mini',
+    '0.0',
+    '3',
+    '120000',
+    '6',
+    '6',
+    'https://api.openai.com/v1',
+    'en-US',
+    true, // enableDependencyAnalysis — U5 专门测这条路径，必须打开
+    '50',
+    true,
+    true,
+    false // enableLintTools
+  )
+}
+
+function makeBot(response = 'ok'): any {
+  return {
+    chat: jest
+      .fn<() => Promise<[string, Record<string, unknown>, unknown[]]>>()
+      .mockResolvedValue([response, {}, []])
+  }
+}
+
+function makePullRequestPayload(overrides: Record<string, any> = {}): any {
+  return {
+    number: 42,
+    title: 'Add dependency analysis path',
+    body: 'body',
+    base: {sha: 'base-sha-0001'},
+    head: {sha: 'head-sha-0001'},
+    ...overrides
+  }
+}
+
+describe('review.ts 双轨一致性（execCtx vs context，Phase 0 依赖分析调用）', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.eventName = 'pull_request'
+    mockContext.actor = 'someone'
+    mockContext.payload = {action: 'opened', pull_request: makePullRequestPayload()}
+    mockContext.repo = {owner: 'octo', repo: 'demo'}
+
+    commenterState.getDescription.mockImplementation((body: string) => body ?? '')
+    commenterState.findCommentWithTag.mockResolvedValue(null)
+    commenterState.getAllCommitIds.mockResolvedValue([])
+    commenterState.addInProgressStatus.mockReturnValue('IN_PROGRESS')
+    commenterState.addReviewedCommitId.mockReturnValue('<!-- reviewed-commit-ids -->')
+
+    octokitState.compareCommits.mockResolvedValue({
+      data: {
+        files: [
+          {
+            filename: 'src/foo.ts',
+            status: 'modified',
+            patch: '@@ -1,3 +1,4 @@\n line1\n line2\n+added line\n line3'
+          }
+        ],
+        commits: [{sha: 'head-sha-0001'}]
+      }
+    })
+    octokitState.getContent.mockResolvedValue({
+      data: {type: 'file', content: Buffer.from('line1\nline2\nline3').toString('base64')}
+    })
+
+    repoTreeState.getRepoFileTree.mockResolvedValue([])
+    dependencyAnalyzerState.analyzeDependencies.mockResolvedValue({fileAnalyses: new Map()})
+  })
+
+  test('execCtx（真实工厂构造）与 context 对同一事件算出的 headSha 一致', () => {
+    // 前置断言：不依赖 codeReview 内部行为，直接验证两套构造路径本身的取值一致性——
+    // 这是"双轨"这个词真正的含义：两套独立代码路径读同一个底层事件，必须得到相同答案。
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.headSha).toBe(mockContext.payload.pull_request.head.sha)
+    expect(execCtx.baseSha).toBe(mockContext.payload.pull_request.base.sha)
+    expect(execCtx.changeRequestId).toBe(mockContext.payload.pull_request.number)
+  })
+
+  test('正常 PR 事件：getRepoFileTree/analyzeDependencies 收到的 ref/headSha 等于 execCtx.headSha 也等于 context.payload.pull_request.head.sha', async () => {
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.headSha).toBe('head-sha-0001') // 前置确认 fixture 搭建正确
+
+    await codeReview(
+      execCtx,
+      makeBot('[TRIAGE]: APPROVED\nLGTM'),
+      makeBot(),
+      makeOptions(),
+      new Prompts('', '')
+    )
+
+    expect(repoTreeState.getRepoFileTree).toHaveBeenCalledTimes(1)
+    const [ref, project] = repoTreeState.getRepoFileTree.mock.calls[0] as any[]
+    expect(ref).toBe(execCtx.headSha)
+    expect(ref).toBe(mockContext.payload.pull_request.head.sha)
+    expect(project).toEqual({platform: 'github', owner: 'octo', repo: 'demo'})
+
+    expect(dependencyAnalyzerState.analyzeDependencies).toHaveBeenCalledTimes(1)
+    const depArgs = dependencyAnalyzerState.analyzeDependencies.mock.calls[0] as any[]
+    const headShaArgPosition = 5 // (filesAndChanges, repoFiles, options, concurrencyLimit, project, headSha, patchScans)
+    expect(depArgs[headShaArgPosition]).toBe(execCtx.headSha)
+    expect(depArgs[headShaArgPosition]).toBe(mockContext.payload.pull_request.head.sha)
+  })
+
+  test('execCtx.headSha 为空（评论触发场景）时，回退到 context.payload.pull_request.head.sha，不传出空字符串', async () => {
+    // 模拟评论触发命令场景：execCtx 来自评论事件（GitHub 工厂对 comment 事件固定
+    // 返回空字符串 headSha，见 github-execution-context.ts），但 codeReview 内部
+    // 的 context 仍然是完整的 PR 事件 payload（fromCommand 场景下 review.ts 会
+    // 自行通过 octokit 补齐 context.payload.pull_request，这里直接构造等价结果）。
+    const commentExecCtx: any = {
+      platform: 'github',
+      projectPath: 'octo/demo',
+      projectId: 'octo/demo',
+      changeRequestId: 42,
+      eventKind: 'comment_created',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: '', // 关键：评论事件的 execCtx 天生没有 headSha
+      comment: {kind: 'top_level', id: 1},
+      raw: {}
+    }
+    expect(commentExecCtx.headSha).toBe('')
+
+    await codeReview(
+      commentExecCtx,
+      makeBot('[TRIAGE]: APPROVED\nLGTM'),
+      makeBot(),
+      makeOptions(),
+      new Prompts('', ''),
+      {source: 'command', mode: 'incremental'}
+    )
+
+    expect(repoTreeState.getRepoFileTree).toHaveBeenCalledTimes(1)
+    const [ref] = repoTreeState.getRepoFileTree.mock.calls[0] as any[]
+    // 空字符串是 falsy，|| 回退到 context 的值，不会把空字符串传给下游
+    expect(ref).toBe('head-sha-0001')
+    expect(ref).toBe(mockContext.payload.pull_request.head.sha)
+    expect(ref).not.toBe('')
+
+    const depArgs = dependencyAnalyzerState.analyzeDependencies.mock.calls[0] as any[]
+    expect(depArgs[5]).toBe('head-sha-0001')
+  })
+})


### PR DESCRIPTION
Closes #62

## 当前进度（2026-07-23）

- ✅ 设计文档（`docs/tasks/execution-context-design.md`）
- ✅ 阶段零：改造前特征化测试基线（`__tests__/characterization/`）
- ✅ 阶段一 T1-T8：`ExecutionContext` 类型定义 + GitHub/GitLab 工厂函数 + `main.ts`/`command-handler.ts`/`early-reaction.ts`/`review-state.ts`/`repo-tree.ts`/`dependency-analyzer.ts`/`conversation.ts` 消费改造 + fail-closed 处理
- ✅ 阶段二：单元测试（U1-U5）— 52 个新用例：github-execution-context.test.ts（13）/ gitlab-execution-context.test.ts（15）/ execution-context-error.test.ts（9）/ command-handler.test.ts（12，此前零覆盖）/ review-execctx-consistency.test.ts（3，验证 T7 的 execCtx||context 回退表达式）
- ✅ 阶段三：集成测试（I1-I3）— 12 个新用例：execution-context.integration.test.ts（I1，2，main.ts→ExecutionContext→codeReview/handleCommentEvent 全链路，唯一一处不在任何一层 mock 隔断的测试）/ gitlab-execution-context.integration.test.ts（I2，10，全部 9 个 GitLab fixture 的完整字段快照）/ I3 用 `env -i` 构造真正干净环境验证 GitHub-only（对齐 GH-016）

**阶段零~三全部完成。**

## 范围调整说明

实施中发现 `commands/dispatcher.ts`（既有 8+ 用例测试覆盖 + GitHub 专有 API 深耦合）和 `commenter.ts`（5 处 `new Commenter()` 调用点、42 处引用）的完整迁移风险高于预期，已调整为与 `review.ts` 相同的"签名透传、内部延后"策略，完整迁移移入阶段四。详见设计文档 6.2.1 节。

## 验证

- `tsc --noEmit` 全绿
- `npm test`：466 通过 / 3 跳过，仅 3 个既有失败套件（`resolve.test.ts`/`resolve.integration.test.ts` 未解决的 merge conflict 标记、`lint-tool-installer.test.ts` 缺失符号）与本次改动无关，已确认同样存在于 `origin/main`

仍为 Draft：阶段二/三测试尚未完成，暂不建议合并。

## 开发过程记录（问题与处理，留存备查）

- **`main.ts` 顶层 `await` 编译问题**：ts-jest 的 CommonJS 转译不支持顶层 `await`，导致 `main.ts` 完全无法被测试 import。改为立即执行的 async 函数（`void (async () => {...})()`）。这是本次改造中唯一一处主动修改的生产代码逻辑（而非纯签名/参数改动），已用 `tsc --noEmit`（真实构建 tsconfig）和全量测试套件验证对运行时行为无可观察影响。
- **`git checkout -b + push -u` 误推事故**：本分支创建初期，用 `git checkout -b feat/execution-context origin/main` 建分支后裸 `git push -u origin feat/execution-context`，因 upstream 被自动设为 `origin/main`，导致 commit 被误推到 `main`。已用 `git revert`（未用 force push/reset 破坏历史）修复，`main` 恢复原状。该陷阱已记入全局记忆并固化进 `/feature-kickoff` 命令（今后建分支流程强制走显式 refspec + 事后校验）。
- **两次非本会话触发的多余 commit**：分支历史中出现过两次不是当前操作产生的 commit（把已经从本分支移出的 memory 文件重新加了回来），均已用 `git revert` 清理，未强改历史。**未查明具体来源**，怀疑是同一工作目录下有其他终端/工具并行操作，建议排查。
- 3 个跟本次改动无关的既有失败测试套件（见上方"验证"）已确认是 `origin/main` 上的既有问题，非本次引入。

## 关联文档

- Issue #62（任务清单已同步勾选进度）
- 方案来源：`codesentinel-docs` 仓库 `docs/migration-plan/`（TODO 清单 v2.5 第 4.1 节）
- 仓库内记忆：`memory/gitlab_migration_plan.md`