### PR TITLE
feat: GitLab trigger CLI 入口与 payload 解析（EVENT-001~005）

### DIFF
--- a/__tests__/command-handler.test.ts
+++ b/__tests__/command-handler.test.ts
@@ -1,0 +1,262 @@
+/**
+ * command-handler.test.ts — handleCommentEvent() 回归测试（U4）
+ *
+ * command-handler.ts 在 ARCH-005/T5 完成了全量迁移（execCtx 取代直接
+ * import @actions/github），但此前没有任何专门测试覆盖过它。本文件补齐这块
+ * 覆盖，验证 execCtx 正确透传给 dispatchCommentEvent/codeReview，以及
+ * fallback_conversation 分支按 execCtx.eventKind 正确二选一（不误触发/不双发）。
+ * 对齐 docs/tasks/execution-context-design.md 第 9.2 节 U4 / TODO TEST-001。
+ */
+import {describe, expect, test, jest, beforeEach} from '@jest/globals'
+
+jest.mock('@actions/core', () => ({
+  info: jest.fn()
+}))
+
+const bootstrapState = {bootstrapCommands: jest.fn()}
+jest.mock('./../src/commands/bootstrap', () => ({
+  bootstrapCommands: (...a: any[]) => bootstrapState.bootstrapCommands(...a)
+}))
+
+const dispatcherState = {
+  dispatchCommentEvent: jest.fn<(...a: any[]) => Promise<any>>()
+}
+jest.mock('./../src/commands/dispatcher', () => ({
+  dispatchCommentEvent: (...a: any[]) => dispatcherState.dispatchCommentEvent(...a)
+}))
+
+const reviewState = {codeReview: jest.fn<(...a: any[]) => Promise<void>>()}
+jest.mock('./../src/review', () => ({
+  codeReview: (...a: any[]) => reviewState.codeReview(...a)
+}))
+
+const conversationState = {
+  handleConversation: jest.fn<(...a: any[]) => Promise<void>>(),
+  handleIssueConversation: jest.fn<(...a: any[]) => Promise<void>>()
+}
+jest.mock('./../src/conversation', () => ({
+  handleConversation: (...a: any[]) => conversationState.handleConversation(...a),
+  handleIssueConversation: (...a: any[]) =>
+    conversationState.handleIssueConversation(...a)
+}))
+
+import {handleCommentEvent} from '../src/command-handler'
+
+function makeExecCtx(overrides: Record<string, any> = {}): any {
+  return {
+    platform: 'github',
+    projectPath: 'octo/demo',
+    projectId: 'octo/demo',
+    changeRequestId: 42,
+    eventKind: 'comment_created',
+    actor: {login: 'alice', isBot: false},
+    baseSha: '',
+    headSha: '',
+    raw: {},
+    ...overrides
+  }
+}
+
+const stubOptions: any = {}
+const stubPrompts: any = {}
+const lightBot: any = {chat: jest.fn()}
+const heavyBot: any = {chat: jest.fn()}
+
+describe('handleCommentEvent()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'ignored', reason: 'x'})
+    reviewState.codeReview.mockResolvedValue(undefined)
+    conversationState.handleConversation.mockResolvedValue(undefined)
+    conversationState.handleIssueConversation.mockResolvedValue(undefined)
+  })
+
+  test('始终调用 bootstrapCommands()', async () => {
+    await handleCommentEvent({execCtx: makeExecCtx(), options: stubOptions, prompts: stubPrompts})
+    expect(bootstrapState.bootstrapCommands).toHaveBeenCalledTimes(1)
+  })
+
+  test('把 execCtx 和 options 透传给 dispatchCommentEvent，并提供 triggerReview 函数', async () => {
+    const execCtx = makeExecCtx()
+    await handleCommentEvent({execCtx, options: stubOptions, prompts: stubPrompts})
+
+    expect(dispatcherState.dispatchCommentEvent).toHaveBeenCalledTimes(1)
+    const arg = dispatcherState.dispatchCommentEvent.mock.calls[0][0] as any
+    expect(arg.execCtx).toBe(execCtx)
+    expect(arg.options).toBe(stubOptions)
+    expect(typeof arg.triggerReview).toBe('function')
+  })
+
+  test('triggerReview("incremental") 调用 codeReview，execCtx 作为首参，mode=incremental', async () => {
+    const execCtx = makeExecCtx()
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('incremental')
+      return {kind: 'executed', command: 'review', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx,
+      lightBot,
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(reviewState.codeReview).toHaveBeenCalledTimes(1)
+    const [ctxArg, lb, hb, opts, prompts, runOptions] = reviewState.codeReview.mock
+      .calls[0] as any[]
+    expect(ctxArg).toBe(execCtx)
+    expect(lb).toBe(lightBot)
+    expect(hb).toBe(heavyBot)
+    expect(opts).toBe(stubOptions)
+    expect(prompts).toBe(stubPrompts)
+    expect(runOptions).toEqual({mode: 'incremental', source: 'command', summaryOnly: false})
+  })
+
+  test('triggerReview("full") → mode=full, summaryOnly=false', async () => {
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('full')
+      return {kind: 'executed', command: 'full review', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx(),
+      lightBot,
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    const runOptions = reviewState.codeReview.mock.calls[0][5]
+    expect(runOptions).toEqual({mode: 'full', source: 'command', summaryOnly: false})
+  })
+
+  test('triggerReview("summary") → mode=full（非 incremental）, summaryOnly=true', async () => {
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('summary')
+      return {kind: 'executed', command: 'summary', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx(),
+      lightBot,
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    const runOptions = reviewState.codeReview.mock.calls[0][5]
+    expect(runOptions).toEqual({mode: 'full', source: 'command', summaryOnly: true})
+  })
+
+  test('triggerReview：lightBot/heavyBot 和 getReviewBots 均不可用时抛错，不调用 codeReview', async () => {
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await expect(deps.triggerReview('incremental')).rejects.toThrow(
+        'OpenAI bot is unavailable for review command'
+      )
+      return {kind: 'executed', command: 'review', ok: false}
+    })
+
+    await handleCommentEvent({execCtx: makeExecCtx(), options: stubOptions, prompts: stubPrompts})
+    expect(reviewState.codeReview).not.toHaveBeenCalled()
+  })
+
+  test('triggerReview：优先用直接传入的 lightBot/heavyBot，其次才用 getReviewBots()', async () => {
+    const getReviewBots = jest.fn(() => ({lightBot, heavyBot}))
+    dispatcherState.dispatchCommentEvent.mockImplementation(async (deps: any) => {
+      await deps.triggerReview('incremental')
+      return {kind: 'executed', command: 'review', ok: true}
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx(),
+      lightBot,
+      heavyBot,
+      getReviewBots,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(getReviewBots).not.toHaveBeenCalled()
+    expect(reviewState.codeReview).toHaveBeenCalledTimes(1)
+  })
+
+  test('outcome.kind !== fallback_conversation → 不触发任何对话式追问', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({
+      kind: 'executed',
+      command: 'review',
+      ok: true
+    })
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx({eventKind: 'review_comment_created'}),
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation + eventKind=review_comment_created → 调用 handleConversation，不调用 handleIssueConversation', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+    const execCtx = makeExecCtx({eventKind: 'review_comment_created'})
+
+    await handleCommentEvent({execCtx, heavyBot, options: stubOptions, prompts: stubPrompts})
+
+    expect(conversationState.handleConversation).toHaveBeenCalledTimes(1)
+    expect(conversationState.handleConversation).toHaveBeenCalledWith(
+      execCtx,
+      heavyBot,
+      stubOptions,
+      stubPrompts
+    )
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation + eventKind=comment_created → 调用 handleIssueConversation，不调用 handleConversation', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+    const execCtx = makeExecCtx({eventKind: 'comment_created'})
+
+    await handleCommentEvent({execCtx, heavyBot, options: stubOptions, prompts: stubPrompts})
+
+    expect(conversationState.handleIssueConversation).toHaveBeenCalledTimes(1)
+    expect(conversationState.handleIssueConversation).toHaveBeenCalledWith(
+      execCtx,
+      heavyBot,
+      stubOptions,
+      stubPrompts
+    )
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation + 不支持的 eventKind（如 pr_opened）→ 两个对话处理器都不调用', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+
+    await handleCommentEvent({
+      execCtx: makeExecCtx({eventKind: 'pr_opened'}),
+      heavyBot,
+      options: stubOptions,
+      prompts: stubPrompts
+    })
+
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+
+  test('fallback_conversation 但 heavyBot 和 getReviewBots 均不可用 → 静默跳过，不抛错', async () => {
+    dispatcherState.dispatchCommentEvent.mockResolvedValue({kind: 'fallback_conversation'})
+
+    await expect(
+      handleCommentEvent({
+        execCtx: makeExecCtx({eventKind: 'comment_created'}),
+        options: stubOptions,
+        prompts: stubPrompts
+      })
+    ).resolves.toBeUndefined()
+
+    expect(conversationState.handleConversation).not.toHaveBeenCalled()
+    expect(conversationState.handleIssueConversation).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/execution-context-error.test.ts
+++ b/__tests__/execution-context-error.test.ts
@@ -1,0 +1,55 @@
+/**
+ * execution-context-error.test.ts — ExecutionContextError 分类断言（U3）
+ *
+ * 覆盖 ExecutionContextError 类本身的行为（构造参数正确赋值、name/instanceof），
+ * 以及 GitHub/GitLab 两个工厂函数分别在哪些 reason 下抛出该错误的矩阵验证。
+ *
+ * 注：ExecutionContextError.reason 的类型定义包含 4 种取值
+ * （missing_payload/malformed_payload/unknown_event/missing_required_field），
+ * 但当前两个工厂函数实际只会抛出其中 3 种——`malformed_payload` 目前没有任何
+ * 调用点使用（GitLab CLI 的 JSON.parse 失败发生在 gitlab-trigger.ts 里，在
+ * 调用 createGitLabExecutionContext 之前就已经处理掉，不会变成
+ * ExecutionContextError）。这是已知的、有意保留的预留分类，不是本测试的缺陷，
+ * 对齐设计文档 9.2 节 U3"三种 reason 分类断言"的原始措辞。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+describe('ExecutionContextError', () => {
+  test('构造函数正确赋值 message/platform/reason，name 固定为 ExecutionContextError', () => {
+    const e = new ExecutionContextError('boom', 'github', 'unknown_event')
+
+    expect(e.message).toBe('boom')
+    expect(e.platform).toBe('github')
+    expect(e.reason).toBe('unknown_event')
+    expect(e.name).toBe('ExecutionContextError')
+  })
+
+  test('是 Error 的实例，也是 ExecutionContextError 的实例', () => {
+    const e = new ExecutionContextError('boom', 'gitlab', 'missing_payload')
+    expect(e).toBeInstanceOf(Error)
+    expect(e).toBeInstanceOf(ExecutionContextError)
+  })
+
+  test.each([
+    {platform: 'github', reason: 'missing_payload'},
+    {platform: 'github', reason: 'unknown_event'},
+    {platform: 'github', reason: 'missing_required_field'},
+    {platform: 'gitlab', reason: 'missing_payload'},
+    {platform: 'gitlab', reason: 'unknown_event'},
+    {platform: 'gitlab', reason: 'missing_required_field'}
+  ] as const)(
+    '$platform 平台可以构造 reason=$reason 的错误，且字段可读',
+    ({platform, reason}) => {
+      const e = new ExecutionContextError(`${platform}/${reason} test`, platform, reason)
+      expect(e.platform).toBe(platform)
+      expect(e.reason).toBe(reason)
+    }
+  )
+
+  test('malformed_payload 是类型定义里预留但当前两个工厂函数均未使用的 reason（记录现状，非缺陷）', () => {
+    // 仍然能正常构造——只是没有任何生产代码路径会触发它
+    const e = new ExecutionContextError('reserved', 'github', 'malformed_payload')
+    expect(e.reason).toBe('malformed_payload')
+  })
+})

--- a/__tests__/execution-context.integration.test.ts
+++ b/__tests__/execution-context.integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * execution-context.integration.test.ts — main.ts → ExecutionContext →
+ * codeReview()/handleCommentEvent() 全链路集成测试（I1）
+ *
+ * 阶段零/二的既有测试都在链路的某一层做了 mock 隔断：
+ *   - main.characterization.test.ts：codeReview/handleCommentEvent 被 mock，
+ *     只验证 main.ts 的分发逻辑本身。
+ *   - review-execctx-consistency.test.ts（U5）：直接调用 codeReview()，
+ *     不经过 main.ts 的事件分发。
+ *   - command-dispatcher.test.ts：triggerReview 被 mock，不真正跑 codeReview。
+ *   - command-handler.test.ts（U4）：dispatchCommentEvent/codeReview 被 mock。
+ *
+ * 本文件是唯一一处让 main.ts（真实 run()）→ createGitHubExecutionContext
+ * （真实）→ command-handler/dispatcher（真实）→ codeReview（真实）全部串联、
+ * 只在最外层 I/O 边界（octokit/Bot/Commenter/文件系统）打桩的测试，验证这条
+ * "从 GitHub 事件到实际业务逻辑"的链路没有断点。
+ *
+ * 覆盖 I1 要求的 pull_request（自动审查）+ issue_comment（命令分发）两类事件；
+ * pull_request_review_comment 与 issue_comment 在 dispatcher.ts 里走几乎相同
+ * 的代码路径（差异只在如何取 PR number/comment），且已被 command-dispatcher.
+ * test.ts 和 main.characterization.test.ts 分别独立验证过，本文件不重复第三个
+ * 全链路场景，是刻意的范围取舍。
+ *
+ * 参考 docs/tasks/execution-context-design.md 第 9.3 节 I1。
+ */
+import {describe, expect, test, jest, beforeEach} from '@jest/globals'
+
+const coreState = {
+  getBooleanInput: jest.fn<(name: string) => boolean>(),
+  getMultilineInput: jest.fn<(...a: any[]) => string[]>().mockReturnValue([]),
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  setFailed: jest.fn()
+}
+// 数值型 input 必须给合法字符串——main.ts 把 getInput() 的结果直接传给 Options
+// 构造函数，空字符串会被 parseInt/parseFloat 成 NaN，导致 codeReview 内部的
+// maxFiles/token 预算判断全部失效（体现为"一个文件都不处理"）。
+const NUMERIC_INPUT_DEFAULTS: Record<string, string> = {
+  max_files: '0',
+  openai_model_temperature: '0.0',
+  openai_retries: '3',
+  openai_timeout_ms: '120000',
+  openai_concurrency_limit: '6',
+  github_concurrency_limit: '6',
+  max_dependency_files: '50',
+  max_review_comments: '20',
+  debug_resolve_inject_failures: '0'
+}
+const getInputMock = jest.fn<(name: string) => string>((name: string) => {
+  return NUMERIC_INPUT_DEFAULTS[name] ?? ''
+})
+jest.mock('@actions/core', () => ({
+  getInput: (...a: any[]) => getInputMock(...(a as [string])),
+  getBooleanInput: (...a: any[]) => coreState.getBooleanInput(...(a as [string])),
+  getMultilineInput: (...a: any[]) => coreState.getMultilineInput(...a),
+  info: (...a: any[]) => coreState.info(...a),
+  warning: (...a: any[]) => coreState.warning(...a),
+  error: (...a: any[]) => coreState.error(...a),
+  setFailed: (...a: any[]) => coreState.setFailed(...a)
+}))
+
+const mockContext: any = {
+  eventName: '',
+  actor: 'someone',
+  payload: {},
+  repo: {owner: 'octo', repo: 'demo'}
+}
+jest.mock('@actions/github', () => ({context: mockContext}))
+
+// main.ts 是 `new Bot(...)`（非 type-only），必须 mock 掉，否则会因缺少
+// OPENAI_API_KEY 在 createBots() 内部抛错，导致后续分支永远走不到。
+const botState = {chat: jest.fn<() => Promise<[string, Record<string, unknown>, unknown[]]>>()}
+jest.mock('../src/bot', () => ({
+  Bot: jest.fn().mockImplementation(() => ({chat: (...a: any[]) => botState.chat(...(a as []))})),
+  OpenAIOptions: jest.fn()
+}))
+
+const octokitState = {
+  compareCommits: jest.fn<(...a: any[]) => Promise<any>>(),
+  getContent: jest.fn<(...a: any[]) => Promise<any>>(),
+  pullsGet: jest.fn<(...a: any[]) => Promise<any>>(),
+  getCollaboratorPermissionLevel: jest.fn<(...a: any[]) => Promise<any>>(),
+  listComments: jest.fn<(...a: any[]) => Promise<any>>(),
+  createComment: jest.fn<(...a: any[]) => Promise<any>>(),
+  updateComment: jest.fn<(...a: any[]) => Promise<any>>(),
+  createReactionForIssueComment: jest.fn<(...a: any[]) => Promise<any>>(),
+  createReactionForPRComment: jest.fn<(...a: any[]) => Promise<any>>()
+}
+jest.mock('../src/octokit', () => ({
+  octokit: {
+    repos: {
+      compareCommits: (...a: any[]) => octokitState.compareCommits(...a),
+      getCollaboratorPermissionLevel: (...a: any[]) =>
+        octokitState.getCollaboratorPermissionLevel(...a)
+    },
+    pulls: {
+      get: (...a: any[]) => octokitState.pullsGet(...a)
+    },
+    issues: {
+      listComments: (...a: any[]) => octokitState.listComments(...a),
+      createComment: (...a: any[]) => octokitState.createComment(...a),
+      updateComment: (...a: any[]) => octokitState.updateComment(...a)
+    },
+    reactions: {
+      createForIssueComment: (...a: any[]) =>
+        octokitState.createReactionForIssueComment(...a),
+      createForPullRequestReviewComment: (...a: any[]) =>
+        octokitState.createReactionForPRComment(...a)
+    }
+  }
+}))
+
+const commenterState = {
+  getDescription: jest.fn((body: string) => body ?? ''),
+  findCommentWithTag: jest.fn<() => Promise<any>>().mockResolvedValue(null),
+  getAllCommitIds: jest.fn<() => Promise<any[]>>().mockResolvedValue([]),
+  getHighestReviewedCommitId: jest.fn().mockReturnValue(''),
+  getReviewedCommitIds: jest.fn().mockReturnValue([]),
+  getReviewedCommitIdsBlock: jest.fn().mockReturnValue(''),
+  getRawSummary: jest.fn().mockReturnValue(''),
+  getShortSummary: jest.fn().mockReturnValue(''),
+  addInProgressStatus: jest.fn().mockReturnValue('IN_PROGRESS'),
+  comment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  updateDescription: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  submitReview: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  addReviewedCommitId: jest.fn().mockReturnValue('<!-- reviewed-commit-ids -->'),
+  bufferReviewComment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  listReviewComments: jest.fn<() => Promise<any[]>>().mockResolvedValue([])
+}
+jest.mock('../src/commenter', () => ({
+  Commenter: jest.fn().mockImplementation(() => commenterState),
+  COMMENT_TAG: '<!-- bot-comment -->',
+  COMMENT_REPLY_TAG: '<!-- bot-reply -->',
+  RAW_SUMMARY_START_TAG: '<!-- raw-summary-start -->',
+  RAW_SUMMARY_END_TAG: '<!-- raw-summary-end -->',
+  SHORT_SUMMARY_START_TAG: '<!-- short-summary-start -->',
+  SHORT_SUMMARY_END_TAG: '<!-- short-summary-end -->',
+  SUMMARIZE_TAG: '<!-- summarize -->'
+}))
+
+jest.mock('../src/tokenizer', () => ({getTokenCount: () => 0}))
+jest.mock('../src/github/review-thread', () => ({
+  fetchThreadStatusMap: jest.fn<() => Promise<Map<string, boolean>>>().mockResolvedValue(new Map())
+}))
+
+function makePullRequestPayload(overrides: Record<string, any> = {}): any {
+  return {
+    number: 42,
+    title: 'Integration test PR',
+    body: 'body',
+    base: {sha: 'base-sha-0001'},
+    head: {sha: 'head-sha-0001'},
+    ...overrides
+  }
+}
+
+describe('I1: main.ts → ExecutionContext → codeReview/handleCommentEvent 全链路', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.GITHUB_EVENT_NAME
+    coreState.getBooleanInput.mockReturnValue(false)
+    coreState.getMultilineInput.mockReturnValue([])
+    getInputMock.mockImplementation((name: string) => NUMERIC_INPUT_DEFAULTS[name] ?? '')
+    botState.chat.mockResolvedValue(['[TRIAGE]: APPROVED\nLGTM', {}, []])
+
+    mockContext.actor = 'someone'
+    mockContext.payload = {}
+
+    commenterState.getDescription.mockImplementation((body: string) => body ?? '')
+    commenterState.findCommentWithTag.mockResolvedValue(null)
+    commenterState.getAllCommitIds.mockResolvedValue([])
+    commenterState.addInProgressStatus.mockReturnValue('IN_PROGRESS')
+    commenterState.addReviewedCommitId.mockReturnValue('<!-- reviewed-commit-ids -->')
+
+    octokitState.compareCommits.mockResolvedValue({
+      data: {
+        files: [
+          {
+            filename: 'src/foo.ts',
+            status: 'modified',
+            patch: '@@ -1,3 +1,4 @@\n line1\n line2\n+added line\n line3'
+          }
+        ],
+        commits: [{sha: 'head-sha-0001'}]
+      }
+    })
+    octokitState.getContent.mockResolvedValue({
+      data: {type: 'file', content: Buffer.from('line1\nline2\nline3').toString('base64')}
+    })
+  })
+
+  async function runMain(): Promise<void> {
+    jest.resetModules()
+    await import('../src/main')
+    await new Promise(resolve => setImmediate(resolve))
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  test('pull_request(opened) → 真实 codeReview 跑完全流程，最终发布带 SUMMARIZE_TAG 的摘要评论', async () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.eventName = 'pull_request'
+    mockContext.payload = {action: 'opened', pull_request: makePullRequestPayload()}
+
+    await runMain()
+
+    // in-progress 状态 + 最终摘要，两次 comment 调用，均带 SUMMARIZE_TAG + replace
+    expect(commenterState.comment).toHaveBeenCalledTimes(2)
+    for (const call of commenterState.comment.mock.calls) {
+      expect(call[1]).toBe('<!-- summarize -->')
+      expect(call[2]).toBe('replace')
+    }
+    // 证明真的走到了 diff 获取这一步（而不是在事件分发层就被吞掉）
+    expect(octokitState.compareCommits).toHaveBeenCalled()
+    expect(coreState.setFailed).not.toHaveBeenCalled()
+  })
+
+  test('issue_comment("@ai-reviewer help") → 真实 dispatcher 路由到 help handler，通过 octokit 发布回复', async () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.eventName = 'issue_comment'
+    mockContext.payload = {
+      action: 'created',
+      issue: {number: 42, pull_request: {}},
+      comment: {
+        id: 9001,
+        body: '@ai-reviewer help',
+        user: {login: 'alice', type: 'User'}
+      }
+    }
+    octokitState.getCollaboratorPermissionLevel.mockResolvedValue({
+      data: {permission: 'read'} // help 命令只需 Reporter/read 级别权限
+    })
+    octokitState.listComments.mockResolvedValue({data: []})
+    octokitState.createComment.mockResolvedValue({data: {id: 5555}})
+    octokitState.createReactionForIssueComment.mockResolvedValue({data: {id: 1}})
+
+    await runMain()
+
+    // help 命令走顶层 issue comment 回复（issues.createComment），不需要 codeReview/Bot
+    expect(octokitState.createComment).toHaveBeenCalled()
+    const [callArgs] = octokitState.createComment.mock.calls[0] as any[]
+    expect(callArgs.owner).toBe('octo')
+    expect(callArgs.repo).toBe('demo')
+    expect(callArgs.issue_number).toBe(42)
+    expect(coreState.setFailed).not.toHaveBeenCalled()
+    // help 命令不需要模型，Bot 不应被调用
+    expect(botState.chat).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/fixtures/gitlab-malformed.json
+++ b/__tests__/fixtures/gitlab-malformed.json
@@ -1,0 +1,13 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 9003,
+    "title": "Missing iid and source/target project ids"
+  }
+}

--- a/__tests__/fixtures/gitlab-mr-hook-fork.json
+++ b/__tests__/fixtures/gitlab-mr-hook-fork.json
@@ -1,0 +1,23 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "bob", "name": "Bob"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9002,
+    "iid": 8,
+    "title": "Fork contribution",
+    "source_branch": "feat/from-fork",
+    "target_branch": "main",
+    "source_project_id": 99,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "open",
+    "last_commit": {"id": "head-sha-fork-0001"}
+  },
+  "changes": {}
+}

--- a/__tests__/fixtures/gitlab-mr-hook-open.json
+++ b/__tests__/fixtures/gitlab-mr-hook-open.json
@@ -1,0 +1,23 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "open",
+    "last_commit": {"id": "head-sha-0001"}
+  },
+  "changes": {}
+}

--- a/__tests__/fixtures/gitlab-mr-hook-update-meta.json
+++ b/__tests__/fixtures/gitlab-mr-hook-update-meta.json
@@ -1,0 +1,32 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures (renamed)",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "update",
+    "last_commit": {"id": "head-sha-0001"}
+  },
+  "changes": {
+    "title": {
+      "previous": "Add characterization fixtures",
+      "current": "Add characterization fixtures (renamed)"
+    },
+    "labels": {
+      "previous": [],
+      "current": [{"title": "needs-review"}]
+    }
+  }
+}

--- a/__tests__/fixtures/gitlab-mr-hook-update-sha.json
+++ b/__tests__/fixtures/gitlab-mr-hook-update-sha.json
@@ -1,0 +1,29 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "update",
+    "oldrev": "head-sha-0001",
+    "last_commit": {"id": "head-sha-0002"}
+  },
+  "changes": {
+    "last_commit": {
+      "previous": {"id": "head-sha-0001"},
+      "current": {"id": "head-sha-0002"}
+    }
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-discussion.json
+++ b/__tests__/fixtures/gitlab-note-hook-discussion.json
@@ -1,0 +1,22 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5002,
+    "note": "@ai-reviewer 这里为什么这样写？",
+    "noteable_type": "MergeRequest",
+    "action": "create",
+    "discussion_id": "abc123discussionid"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-non-create.json
+++ b/__tests__/fixtures/gitlab-note-hook-non-create.json
@@ -1,0 +1,21 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5001,
+    "note": "@ai-reviewer review (edited)",
+    "noteable_type": "MergeRequest",
+    "action": "update"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-toplevel.json
+++ b/__tests__/fixtures/gitlab-note-hook-toplevel.json
@@ -1,0 +1,21 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5001,
+    "note": "@ai-reviewer review",
+    "noteable_type": "MergeRequest",
+    "action": "create"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-unknown-event.json
+++ b/__tests__/fixtures/gitlab-unknown-event.json
@@ -1,0 +1,12 @@
+{
+  "object_kind": "pipeline",
+  "event_type": "pipeline",
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 12345,
+    "status": "success"
+  }
+}

--- a/__tests__/github-execution-context.test.ts
+++ b/__tests__/github-execution-context.test.ts
@@ -1,0 +1,194 @@
+/**
+ * github-execution-context.test.ts — createGitHubExecutionContext() 单元测试（U1）
+ *
+ * 覆盖 4 类 GitHub 事件（PR 开启/更新/重开/元数据更新）+ 2 类评论事件
+ * （issue_comment/pull_request_review_comment）+ 缺字段 fail-closed 场景。
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U1。
+ */
+import {describe, expect, test, beforeEach, jest} from '@jest/globals'
+
+const mockContext: any = {
+  eventName: '',
+  actor: 'octocat',
+  payload: {},
+  repo: {owner: 'octo', repo: 'demo'}
+}
+jest.mock('@actions/github', () => ({context: mockContext}))
+
+import {createGitHubExecutionContext} from '../src/platform/github-execution-context'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+/** 捕获 fn 抛出的异常并返回，未抛出时让测试失败（避免依赖非标准全局 fail()） */
+function getThrownError(fn: () => unknown): unknown {
+  try {
+    fn()
+  } catch (e) {
+    return e
+  }
+  throw new Error('Expected function to throw, but it did not')
+}
+
+function makePr(overrides: Record<string, any> = {}): any {
+  return {
+    number: 42,
+    base: {sha: 'base-sha-0001'},
+    head: {sha: 'head-sha-0001'},
+    ...overrides
+  }
+}
+
+describe('createGitHubExecutionContext()', () => {
+  beforeEach(() => {
+    delete process.env.GITHUB_EVENT_NAME
+    mockContext.eventName = ''
+    mockContext.actor = 'octocat'
+    mockContext.payload = {}
+    mockContext.repo = {owner: 'octo', repo: 'demo'}
+  })
+
+  test('GITHUB_EVENT_NAME 未设置 → ExecutionContextError(missing_payload)', () => {
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).platform).toBe('github')
+    expect((e as ExecutionContextError).reason).toBe('missing_payload')
+  })
+
+  test('不支持的事件类型（如 push）→ ExecutionContextError(unknown_event)', () => {
+    process.env.GITHUB_EVENT_NAME = 'push'
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('unknown_event')
+    expect((e as ExecutionContextError).message).toContain('push')
+  })
+
+  test('pull_request action=opened → eventKind=pr_opened，字段映射正确', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'opened', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+
+    expect(execCtx.platform).toBe('github')
+    expect(execCtx.eventKind).toBe('pr_opened')
+    expect(execCtx.projectPath).toBe('octo/demo')
+    expect(execCtx.projectId).toBe('octo/demo')
+    expect(execCtx.changeRequestId).toBe(42)
+    expect(execCtx.baseSha).toBe('base-sha-0001')
+    expect(execCtx.headSha).toBe('head-sha-0001')
+    expect(execCtx.actor).toEqual({login: 'octocat', isBot: false})
+    expect(execCtx.comment).toBeUndefined()
+    expect(execCtx.raw).toBe(mockContext.payload)
+  })
+
+  test('pull_request_target action=synchronize → eventKind=pr_synchronize', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request_target'
+    mockContext.payload = {action: 'synchronize', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.eventKind).toBe('pr_synchronize')
+  })
+
+  test('pull_request action=reopened → eventKind=pr_reopened', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'reopened', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.eventKind).toBe('pr_reopened')
+  })
+
+  test('pull_request action=labeled（其它元数据更新）→ eventKind=metadata_updated', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'labeled', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.eventKind).toBe('metadata_updated')
+  })
+
+  test('pull_request 事件缺少 pull_request 字段 → ExecutionContextError(missing_required_field)', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.payload = {action: 'opened'}
+
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('issue_comment → eventKind=comment_created，comment.kind=top_level', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {
+      action: 'created',
+      issue: {number: 42},
+      comment: {id: 9001, node_id: 'IC_xxx', user: {login: 'alice'}}
+    }
+
+    const execCtx = createGitHubExecutionContext()
+
+    expect(execCtx.eventKind).toBe('comment_created')
+    expect(execCtx.changeRequestId).toBe(42)
+    expect(execCtx.baseSha).toBe('')
+    expect(execCtx.headSha).toBe('')
+    expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
+    expect(execCtx.comment).toEqual({
+      kind: 'top_level',
+      id: 9001,
+      threadId: 'IC_xxx'
+    })
+  })
+
+  test('pull_request_review_comment → eventKind=review_comment_created，comment.kind=review_thread', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request_review_comment'
+    mockContext.payload = {
+      action: 'created',
+      pull_request: {number: 42},
+      comment: {id: 9002, node_id: 'PRRC_xxx', user: {login: 'bob'}}
+    }
+
+    const execCtx = createGitHubExecutionContext()
+
+    expect(execCtx.eventKind).toBe('review_comment_created')
+    expect(execCtx.changeRequestId).toBe(42)
+    expect(execCtx.comment).toEqual({
+      kind: 'review_thread',
+      id: 9002,
+      threadId: 'PRRC_xxx'
+    })
+  })
+
+  test('评论事件缺少 comment 字段 → ExecutionContextError(missing_required_field)', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {action: 'created', issue: {number: 42}}
+
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('评论事件缺少 PR number（issue/pull_request 均为空） → ExecutionContextError(missing_required_field)', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {action: 'created', comment: {id: 1, user: {}}}
+
+    const e = getThrownError(() => createGitHubExecutionContext())
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('bot 评论者 login 以 [bot] 结尾 → actor.isBot=true', () => {
+    process.env.GITHUB_EVENT_NAME = 'issue_comment'
+    mockContext.payload = {
+      action: 'created',
+      issue: {number: 42},
+      comment: {id: 1, user: {login: 'github-actions[bot]'}}
+    }
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.actor).toEqual({login: 'github-actions[bot]', isBot: true})
+  })
+
+  test('pull_request* 事件的 actor 来自 context.actor（bot 后缀同样识别）', () => {
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.actor = 'dependabot[bot]'
+    mockContext.payload = {action: 'opened', pull_request: makePr()}
+
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.actor).toEqual({login: 'dependabot[bot]', isBot: true})
+  })
+})

--- a/__tests__/gitlab-execution-context.integration.test.ts
+++ b/__tests__/gitlab-execution-context.integration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * gitlab-execution-context.integration.test.ts — GitLab payload 字段完整性验证（I2）
+ *
+ * U2（gitlab-execution-context.test.ts）已经用同一批 fixture 做了逐场景的
+ * 单元测试（每个用例只挑关键字段断言、验证特定分支行为）。本文件换一个角度：
+ * 对全部 9 个共享 fixture 做一次性、完整字段快照比对——确保
+ * createGitLabExecutionContext 产出的 ExecutionContext 对象里，
+ * ExecutionContext 类型定义要求的每一个字段（platform/projectPath/projectId/
+ * changeRequestId/eventKind/actor/baseSha/headSha/comment?/raw）在每个成功
+ * 场景下都被正确、完整地填充，而不只是抽查过的那几个字段。
+ *
+ * 不接真实 GitLab（trigger CLI 尚未存在，见 EVENT-001~005），只用文档里
+ * 整理的 payload 结构手工构造/复用的 fixture。
+ *
+ * 参考 docs/tasks/execution-context-design.md 第 9.3 节 I2。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrUpdateSha from './fixtures/gitlab-mr-hook-update-sha.json'
+import mrUpdateMeta from './fixtures/gitlab-mr-hook-update-meta.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
+import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import unknownEvent from './fixtures/gitlab-unknown-event.json'
+import malformed from './fixtures/gitlab-malformed.json'
+
+const REQUIRED_FIELDS = [
+  'platform',
+  'projectPath',
+  'projectId',
+  'changeRequestId',
+  'eventKind',
+  'actor',
+  'baseSha',
+  'headSha',
+  'raw'
+] as const
+
+describe('I2: GitLab fixture 全字段完整性快照', () => {
+  test('MR open（gitlab-mr-hook-open.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(mrOpen)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'pr_opened',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      raw: mrOpen
+    })
+  })
+
+  test('MR update+SHA变化（gitlab-mr-hook-update-sha.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateSha)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'pr_synchronize',
+      actor: {login: 'alice', isBot: false},
+      baseSha: 'head-sha-0001',
+      headSha: 'head-sha-0002',
+      raw: mrUpdateSha
+    })
+  })
+
+  test('MR update+仅元数据（gitlab-mr-hook-update-meta.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateMeta)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'metadata_updated',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      raw: mrUpdateMeta
+    })
+  })
+
+  test('fork MR（gitlab-mr-hook-fork.json）→ 完整字段快照，projectPath/Id 取自 target project（顶层 project 字段）', () => {
+    const execCtx = createGitLabExecutionContext(mrFork)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 8,
+      eventKind: 'pr_opened',
+      actor: {login: 'bob', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-fork-0001',
+      raw: mrFork
+    })
+  })
+
+  test('Note create 顶层（gitlab-note-hook-toplevel.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(noteToplevel)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'comment_created',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      comment: {kind: 'top_level', id: 5001, threadId: undefined},
+      raw: noteToplevel
+    })
+  })
+
+  test('Note create discussion 回复（gitlab-note-hook-discussion.json）→ 完整字段快照', () => {
+    const execCtx = createGitLabExecutionContext(noteDiscussion)
+    expect(execCtx).toEqual({
+      platform: 'gitlab',
+      projectPath: 'octo/demo',
+      projectId: '42',
+      changeRequestId: 7,
+      eventKind: 'review_comment_created',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: 'head-sha-0001',
+      comment: {kind: 'review_thread', id: 5002, threadId: 'abc123discussionid'},
+      raw: noteDiscussion
+    })
+  })
+
+  test.each([
+    {label: '未知 object_kind', fixture: unknownEvent, expectedReason: 'unknown_event'},
+    {
+      label: '缺少 iid/source-target project',
+      fixture: malformed,
+      expectedReason: 'missing_required_field'
+    },
+    {
+      label: 'note action != create',
+      fixture: noteNonCreate,
+      expectedReason: 'missing_required_field'
+    }
+  ] as const)('$label → 不产出 ExecutionContext，reason=$expectedReason', ({fixture, expectedReason}) => {
+    expect(() => createGitLabExecutionContext(fixture)).toThrow(ExecutionContextError)
+    try {
+      createGitLabExecutionContext(fixture)
+    } catch (e) {
+      expect((e as ExecutionContextError).reason).toBe(expectedReason)
+    }
+  })
+
+  test('全部 6 个成功场景的 ExecutionContext 都包含类型定义要求的全部必需字段', () => {
+    const successfulFixtures = [
+      mrOpen,
+      mrUpdateSha,
+      mrUpdateMeta,
+      mrFork,
+      noteToplevel,
+      noteDiscussion
+    ]
+    for (const fixture of successfulFixtures) {
+      const execCtx = createGitLabExecutionContext(fixture)
+      for (const field of REQUIRED_FIELDS) {
+        expect(execCtx).toHaveProperty(field)
+        expect((execCtx as any)[field]).not.toBeUndefined()
+      }
+    }
+  })
+})

--- a/__tests__/gitlab-execution-context.test.ts
+++ b/__tests__/gitlab-execution-context.test.ts
@@ -1,0 +1,160 @@
+/**
+ * gitlab-execution-context.test.ts — createGitLabExecutionContext() 单元测试（U2）
+ *
+ * 覆盖 MR open/reopen/update(HEAD变化)/update(仅元数据) + Note
+ * create(top-level)/create(discussion回复)/非 create 动作/未知 object_kind，
+ * 复用 __tests__/fixtures/ 下的共享 GitLab payload 样例（阶段一 G4 产出）。
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U2。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+import {ExecutionContextError} from '../src/platform/execution-context'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrUpdateSha from './fixtures/gitlab-mr-hook-update-sha.json'
+import mrUpdateMeta from './fixtures/gitlab-mr-hook-update-meta.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
+import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import unknownEvent from './fixtures/gitlab-unknown-event.json'
+import malformed from './fixtures/gitlab-malformed.json'
+
+/** 捕获 fn 抛出的异常并返回，未抛出时让测试失败（避免依赖非标准全局 fail()） */
+function getThrownError(fn: () => unknown): unknown {
+  try {
+    fn()
+  } catch (e) {
+    return e
+  }
+  throw new Error('Expected function to throw, but it did not')
+}
+
+describe('createGitLabExecutionContext()', () => {
+  test('payload 为 null → ExecutionContextError(missing_payload)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(null))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).platform).toBe('gitlab')
+    expect((e as ExecutionContextError).reason).toBe('missing_payload')
+  })
+
+  test('payload 非对象（字符串）→ ExecutionContextError(missing_payload)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext('not-an-object'))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_payload')
+  })
+
+  test('未知 object_kind（如 pipeline）→ ExecutionContextError(unknown_event)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(unknownEvent))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('unknown_event')
+  })
+
+  test('MR open → eventKind=pr_opened，字段映射正确', () => {
+    const execCtx = createGitLabExecutionContext(mrOpen)
+
+    expect(execCtx.platform).toBe('gitlab')
+    expect(execCtx.eventKind).toBe('pr_opened')
+    expect(execCtx.projectPath).toBe('octo/demo')
+    expect(execCtx.projectId).toBe('42')
+    expect(execCtx.changeRequestId).toBe(7)
+    expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
+    expect(execCtx.headSha).toBe('head-sha-0001')
+    expect(execCtx.comment).toBeUndefined()
+  })
+
+  test('MR update 且 changes.last_commit 存在 → eventKind=pr_synchronize', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateSha)
+
+    expect(execCtx.eventKind).toBe('pr_synchronize')
+    expect(execCtx.headSha).toBe('head-sha-0002')
+    expect(execCtx.baseSha).toBe('head-sha-0001') // oldrev
+  })
+
+  test('MR update 且 changes 只含 title/labels → eventKind=metadata_updated', () => {
+    const execCtx = createGitLabExecutionContext(mrUpdateMeta)
+    expect(execCtx.eventKind).toBe('metadata_updated')
+  })
+
+  test('MR reopen → eventKind=pr_reopened', () => {
+    const reopenPayload = {
+      ...mrOpen,
+      object_attributes: {...(mrOpen as any).object_attributes, action: 'reopen'}
+    }
+    const execCtx = createGitLabExecutionContext(reopenPayload)
+    expect(execCtx.eventKind).toBe('pr_reopened')
+  })
+
+  test('MR 缺少 object_attributes.iid → ExecutionContextError(missing_required_field)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(malformed))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('fork MR（source_project_id != target_project_id）→ 工厂函数本身不做 fork 拒绝，仍正常构造', () => {
+    // ARCH-004 明确不实现 EVENT-010（fork 拒绝）；这里确认工厂函数没有意外提前实现该逻辑
+    const execCtx = createGitLabExecutionContext(mrFork)
+    expect(execCtx.eventKind).toBe('pr_opened')
+    expect(execCtx.changeRequestId).toBe(8)
+  })
+
+  test('Note create（顶层）→ eventKind=comment_created，comment.kind=top_level', () => {
+    const execCtx = createGitLabExecutionContext(noteToplevel)
+
+    expect(execCtx.platform).toBe('gitlab')
+    expect(execCtx.eventKind).toBe('comment_created')
+    expect(execCtx.changeRequestId).toBe(7)
+    expect(execCtx.headSha).toBe('head-sha-0001') // merge_request.diff_head_sha
+    expect(execCtx.baseSha).toBe('')
+    expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
+    expect(execCtx.comment).toEqual({kind: 'top_level', id: 5001, threadId: undefined})
+  })
+
+  test('Note create（discussion 回复）→ eventKind=review_comment_created，comment.kind=review_thread', () => {
+    const execCtx = createGitLabExecutionContext(noteDiscussion)
+
+    expect(execCtx.eventKind).toBe('review_comment_created')
+    expect(execCtx.comment).toEqual({
+      kind: 'review_thread',
+      id: 5002,
+      threadId: 'abc123discussionid'
+    })
+  })
+
+  test('Note action != create → ExecutionContextError(missing_required_field)（已知缺口，见 issue #66：应优雅跳过而非 fail closed，本任务不修复）', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(noteNonCreate))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('Note 缺少 merge_request.iid → ExecutionContextError(missing_required_field)', () => {
+    const payload = {
+      object_kind: 'note',
+      user: {username: 'alice'},
+      project: {id: 42, path_with_namespace: 'octo/demo'},
+      object_attributes: {id: 5001, action: 'create', noteable_type: 'MergeRequest'}
+      // merge_request 字段整个缺失
+    }
+    const e = getThrownError(() => createGitLabExecutionContext(payload))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+  })
+
+  test('Note noteable_type 不是 MergeRequest → ExecutionContextError(unknown_event)', () => {
+    const payload = {
+      object_kind: 'note',
+      user: {username: 'alice'},
+      project: {id: 42, path_with_namespace: 'octo/demo'},
+      object_attributes: {id: 5001, action: 'create', noteable_type: 'Issue'},
+      merge_request: {iid: 7}
+    }
+    const e = getThrownError(() => createGitLabExecutionContext(payload))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('unknown_event')
+  })
+
+  test('isBot 恒为 false（GitLab MVP 用个人 PAT，无天然 bot 标记，见 EVENT-018）', () => {
+    const execCtx = createGitLabExecutionContext(mrOpen)
+    expect(execCtx.actor.isBot).toBe(false)
+  })
+})

--- a/__tests__/gitlab-trigger-redact.test.ts
+++ b/__tests__/gitlab-trigger-redact.test.ts
@@ -1,0 +1,50 @@
+/**
+ * gitlab-trigger-redact.test.ts — redact() 脱敏断言（EVENT-005）
+ *
+ * c9672be 的提交信息里写"redact() 对 4 种 token 形态验证通过"，但那是手动
+ * ts-node 验证，没有留下自动化测试。本文件把那 4 种形态转成 Jest 用例。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {redact} from '../src/gitlab-trigger-redact'
+
+describe('redact()', () => {
+  test('脱敏 GitLab PAT（glpat- 前缀）', () => {
+    expect(redact('token=glpat-AbC123_-xyz failed')).toBe(
+      'token=glpat-*** failed'
+    )
+  })
+
+  test('脱敏 Bearer token（大小写不敏感）', () => {
+    expect(redact('Authorization: bearer AbC123.def-456')).toBe(
+      'Authorization: Bearer ***'
+    )
+  })
+
+  test('脱敏 URL query 中的 token 参数', () => {
+    expect(redact('https://gitlab.example.com/api?token=secret123&x=1')).toBe(
+      'https://gitlab.example.com/api?token=***&x=1'
+    )
+  })
+
+  test('脱敏 URL query 中的 private_token 参数', () => {
+    expect(
+      redact('https://gitlab.example.com/api?private_token=secret456')
+    ).toBe('https://gitlab.example.com/api?private_token=***')
+  })
+
+  test('同一字符串中多种 token 形态同时出现，全部脱敏', () => {
+    const input =
+      'glpat-secret1 Bearer secret2 ?token=secret3&private_token=secret4'
+    const result = redact(input)
+    expect(result).not.toContain('secret1')
+    expect(result).not.toContain('secret2')
+    expect(result).not.toContain('secret3')
+    expect(result).not.toContain('secret4')
+  })
+
+  test('不包含任何 token 形态的普通字符串原样返回', () => {
+    expect(redact('plain error message, nothing sensitive')).toBe(
+      'plain error message, nothing sensitive'
+    )
+  })
+})

--- a/__tests__/gitlab-trigger-validation.test.ts
+++ b/__tests__/gitlab-trigger-validation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * gitlab-trigger-validation.test.ts — validateTriggerPayload() 结构校验断言（EVENT-003）
+ *
+ * c9672be 只用 ts-node 手动跑通了 7 种场景，没有留下自动化测试。本文件补齐
+ * 覆盖，复用与 gitlab-execution-context.test.ts 相同的共享 fixture。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {validateTriggerPayload} from '../src/gitlab-trigger-validation'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+import malformed from './fixtures/gitlab-malformed.json'
+import unknownEvent from './fixtures/gitlab-unknown-event.json'
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+
+describe('validateTriggerPayload()', () => {
+  test('非对象 payload → ok:false', () => {
+    expect(validateTriggerPayload(null)).toEqual({
+      ok: false,
+      reason: 'payload is not an object'
+    })
+    expect(validateTriggerPayload('string')).toEqual({
+      ok: false,
+      reason: 'payload is not an object'
+    })
+  })
+
+  test('未知 object_kind → ok:true（粗过滤放行，交给 ECF 层的 unknown_event 分支处理）', () => {
+    expect(validateTriggerPayload(unknownEvent)).toEqual({ok: true})
+  })
+
+  test('merge_request 正常场景（source==target）→ ok:true, sourceTargetMismatch:false', () => {
+    expect(validateTriggerPayload(mrOpen)).toEqual({
+      ok: true,
+      sourceTargetMismatch: false
+    })
+  })
+
+  test('merge_request fork 场景（source!=target）→ ok:true, sourceTargetMismatch:true', () => {
+    expect(validateTriggerPayload(mrFork)).toEqual({
+      ok: true,
+      sourceTargetMismatch: true
+    })
+  })
+
+  test('merge_request 缺少 iid/source_project_id/target_project_id → ok:false', () => {
+    expect(validateTriggerPayload(malformed)).toEqual({
+      ok: false,
+      reason: 'missing object_attributes.iid'
+    })
+  })
+
+  test('merge_request 缺少 project.id → ok:false', () => {
+    const payload = {
+      object_kind: 'merge_request',
+      project: {},
+      object_attributes: {iid: 1, source_project_id: 1, target_project_id: 1}
+    }
+    expect(validateTriggerPayload(payload)).toEqual({
+      ok: false,
+      reason: 'missing project.id'
+    })
+  })
+
+  test('merge_request 有 iid 但缺少 source/target project id → ok:false', () => {
+    const payload = {
+      object_kind: 'merge_request',
+      project: {id: 42},
+      object_attributes: {iid: 1}
+    }
+    expect(validateTriggerPayload(payload)).toEqual({
+      ok: false,
+      reason: 'missing source_project_id/target_project_id'
+    })
+  })
+
+  test('note 正常场景 → ok:true', () => {
+    expect(validateTriggerPayload(noteToplevel)).toEqual({ok: true})
+  })
+
+  test('note action != create 仍通过结构校验（业务判断留给 ECF 层，即已知的 EVENT-016/017 缺口）→ ok:true', () => {
+    expect(validateTriggerPayload(noteNonCreate)).toEqual({ok: true})
+  })
+
+  test('note 缺少 object_attributes.id → ok:false', () => {
+    const payload = {
+      object_kind: 'note',
+      project: {id: 42},
+      object_attributes: {},
+      merge_request: {iid: 7}
+    }
+    expect(validateTriggerPayload(payload)).toEqual({
+      ok: false,
+      reason: 'missing object_attributes.id'
+    })
+  })
+
+  test('note 缺少 merge_request.iid → ok:false', () => {
+    const payload = {
+      object_kind: 'note',
+      project: {id: 42},
+      object_attributes: {id: 1},
+      merge_request: {}
+    }
+    expect(validateTriggerPayload(payload)).toEqual({
+      ok: false,
+      reason: 'missing merge_request.iid'
+    })
+  })
+
+  test('note 缺少 project.id → ok:false', () => {
+    const payload = {
+      object_kind: 'note',
+      project: {},
+      object_attributes: {id: 1},
+      merge_request: {iid: 7}
+    }
+    expect(validateTriggerPayload(payload)).toEqual({
+      ok: false,
+      reason: 'missing project.id'
+    })
+  })
+})

--- a/__tests__/gitlab-trigger.test.ts
+++ b/__tests__/gitlab-trigger.test.ts
@@ -1,0 +1,151 @@
+/**
+ * gitlab-trigger.test.ts — CLI 入口行为断言（EVENT-001/002/004）
+ *
+ * c9672be 的提交信息称"已用 ts-node 对全部 7 种场景手动跑通验证"，但没有留下
+ * 自动化测试——本文件把那些手动场景转成自动化用例，只 mock `fs.readFileSync`
+ * （文件 IO 边界），validateTriggerPayload/createGitLabExecutionContext/redact
+ * 全部用真实实现，贴近 CLI 实际的端到端行为。
+ *
+ * 覆盖的最后一个用例（note action != create）刻意保留当前的 fail-closed 行为
+ * 并断言之，与 c9672be 提交信息中记录的已知缺口一致：这属于 EVENT-016/017
+ * （Issue #66），本任务范围不修复，只需如实反映现状。
+ */
+import {describe, expect, test, jest, beforeEach, afterEach} from '@jest/globals'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+import malformed from './fixtures/gitlab-malformed.json'
+import unknownEvent from './fixtures/gitlab-unknown-event.json'
+import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+
+const fsState = {readFileSync: jest.fn<(...a: any[]) => string>()}
+jest.mock('fs', () => ({
+  readFileSync: (...a: any[]) => fsState.readFileSync(...a)
+}))
+
+async function runTrigger(): Promise<void> {
+  jest.resetModules()
+  await import('../src/gitlab-trigger')
+  await new Promise(resolve => setImmediate(resolve))
+}
+
+describe('gitlab-trigger.ts run()', () => {
+  let logSpy: jest.SpiedFunction<typeof console.log>
+  let errorSpy: jest.SpiedFunction<typeof console.error>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete process.env.TRIGGER_PAYLOAD
+    process.exitCode = undefined
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    process.exitCode = undefined
+  })
+
+  test('TRIGGER_PAYLOAD 未设置 → 报错退出，不读文件', async () => {
+    await runTrigger()
+
+    expect(errorSpy).toHaveBeenCalledWith('TRIGGER_PAYLOAD is not set')
+    expect(process.exitCode).toBe(1)
+    expect(fsState.readFileSync).not.toHaveBeenCalled()
+  })
+
+  test('文件读取失败 → 报错退出，错误信息脱敏', async () => {
+    process.env.TRIGGER_PAYLOAD = '/no/such/file.json'
+    fsState.readFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: glpat-secretvalue123 not found')
+    })
+
+    await runTrigger()
+
+    expect(process.exitCode).toBe(1)
+    const message = errorSpy.mock.calls[0][0] as string
+    expect(message).toContain('Failed to read TRIGGER_PAYLOAD file')
+    expect(message).not.toContain('secretvalue123')
+    expect(message).toContain('glpat-***')
+  })
+
+  test('文件内容不是合法 JSON → 报错退出，不回显原始内容', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue('not json{{{')
+
+    await runTrigger()
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'TRIGGER_PAYLOAD content is not valid JSON'
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('正常 MR open payload → 打印成功摘要，exitCode 不被设置', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(mrOpen))
+
+    await runTrigger()
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBeUndefined()
+    expect(logSpy).toHaveBeenCalledWith(
+      'GitLab event validated: platform=gitlab eventKind=pr_opened project=octo/demo mr=7'
+    )
+  })
+
+  test('未知 object_kind（EVENT-004）→ 优雅跳过，退出码保持成功', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(unknownEvent))
+
+    await runTrigger()
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBeUndefined()
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped: Unsupported GitLab object_kind: pipeline')
+    )
+  })
+
+  test('结构校验失败（缺 iid）→ 报错退出，不进入 ExecutionContext 构造', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(malformed))
+
+    await runTrigger()
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'TRIGGER_PAYLOAD failed validation: missing object_attributes.iid'
+    )
+    expect(process.exitCode).toBe(1)
+  })
+
+  test('fork MR（source!=target）→ 先打印 EVENT-010 提示，再打印成功摘要', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(mrFork))
+
+    await runTrigger()
+
+    expect(process.exitCode).toBeUndefined()
+    expect(logSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('fork MR')
+    )
+    expect(logSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('mr=8')
+    )
+  })
+
+  test('已知缺口：note action != create 时 fail closed 退出码 1（非优雅跳过，Issue #66 待修）', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(noteNonCreate))
+
+    await runTrigger()
+
+    expect(process.exitCode).toBe(1)
+    const message = errorSpy.mock.calls[0][0] as string
+    expect(message).toContain('Failed to build ExecutionContext')
+    expect(message).toContain('not a create action')
+  })
+})

--- a/__tests__/review-execctx-consistency.test.ts
+++ b/__tests__/review-execctx-consistency.test.ts
@@ -1,0 +1,261 @@
+/**
+ * review-execctx-consistency.test.ts — review.ts 双轨一致性断言（U5）
+ *
+ * review.ts 的 codeReview() 在 T7 新增了 execCtx 首参数，但内部仍以模块级
+ * `context`/`repo`（`@actions/github`）为主要数据源（dual-track 过渡态，
+ * 见设计文档 6.3 节）。唯二真正读取 execCtx 的地方是 Phase 0 依赖分析调用
+ * getRepoFileTree()/analyzeDependencies() 时的 `execCtx.headSha || context.
+ * payload.pull_request.head.sha` 回退表达式。本测试验证：
+ *   1. 正常场景下 execCtx（由 createGitHubExecutionContext() 真实构造）与
+ *      context 两条数据源对同一事件算出的 headSha 一致；
+ *   2. execCtx.headSha 为空（评论触发场景）时，回退表达式正确退回到
+ *      context.payload.pull_request.head.sha，不会传出 undefined/空值。
+ *
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U5。
+ */
+import {describe, expect, test, jest, beforeEach} from '@jest/globals'
+
+jest.mock('@actions/core', () => ({
+  getInput: jest.fn().mockReturnValue(''),
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn()
+}))
+
+const mockContext: any = {
+  eventName: 'pull_request',
+  actor: 'someone',
+  payload: {},
+  repo: {owner: 'octo', repo: 'demo'}
+}
+jest.mock('@actions/github', () => ({context: mockContext}))
+
+const octokitState = {
+  compareCommits: jest.fn<(...a: any[]) => Promise<any>>(),
+  getContent: jest.fn<(...a: any[]) => Promise<any>>(),
+  pullsGet: jest.fn<(...a: any[]) => Promise<any>>()
+}
+jest.mock('../src/octokit', () => ({
+  octokit: {
+    repos: {
+      compareCommits: (...a: any[]) => octokitState.compareCommits(...a),
+      getContent: (...a: any[]) => octokitState.getContent(...a)
+    },
+    pulls: {
+      get: (...a: any[]) => octokitState.pullsGet(...a)
+    }
+  }
+}))
+
+const commenterState = {
+  getDescription: jest.fn((body: string) => body ?? ''),
+  findCommentWithTag: jest.fn<() => Promise<any>>().mockResolvedValue(null),
+  getAllCommitIds: jest.fn<() => Promise<any[]>>().mockResolvedValue([]),
+  getHighestReviewedCommitId: jest.fn().mockReturnValue(''),
+  getReviewedCommitIds: jest.fn().mockReturnValue([]),
+  getReviewedCommitIdsBlock: jest.fn().mockReturnValue(''),
+  getRawSummary: jest.fn().mockReturnValue(''),
+  getShortSummary: jest.fn().mockReturnValue(''),
+  addInProgressStatus: jest.fn().mockReturnValue('IN_PROGRESS'),
+  comment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  updateDescription: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  submitReview: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  addReviewedCommitId: jest.fn().mockReturnValue('<!-- reviewed-commit-ids -->'),
+  bufferReviewComment: jest.fn<(...a: any[]) => Promise<void>>().mockResolvedValue(undefined),
+  listReviewComments: jest.fn<() => Promise<any[]>>().mockResolvedValue([]),
+  getCommentChainsWithinRange: jest.fn<(...a: any[]) => Promise<string>>().mockResolvedValue('')
+}
+jest.mock('../src/commenter', () => ({
+  Commenter: jest.fn().mockImplementation(() => commenterState),
+  COMMENT_TAG: '<!-- bot-comment -->',
+  COMMENT_REPLY_TAG: '<!-- bot-reply -->',
+  RAW_SUMMARY_START_TAG: '<!-- raw-summary-start -->',
+  RAW_SUMMARY_END_TAG: '<!-- raw-summary-end -->',
+  SHORT_SUMMARY_START_TAG: '<!-- short-summary-start -->',
+  SHORT_SUMMARY_END_TAG: '<!-- short-summary-end -->',
+  SUMMARIZE_TAG: '<!-- summarize -->'
+}))
+
+jest.mock('../src/tokenizer', () => ({getTokenCount: () => 0}))
+
+jest.mock('../src/github/review-thread', () => ({
+  fetchThreadStatusMap: jest.fn<() => Promise<Map<string, boolean>>>().mockResolvedValue(new Map())
+}))
+
+const repoTreeState = {
+  getRepoFileTree: jest.fn<(...a: any[]) => Promise<string[]>>().mockResolvedValue([])
+}
+jest.mock('../src/repo-tree', () => ({
+  getRepoFileTree: (...a: any[]) => repoTreeState.getRepoFileTree(...a)
+}))
+
+const dependencyAnalyzerState = {
+  analyzeDependencies: jest
+    .fn<(...a: any[]) => Promise<any>>()
+    .mockResolvedValue({fileAnalyses: new Map()})
+}
+jest.mock('../src/dependency-analyzer', () => ({
+  analyzeDependencies: (...a: any[]) => dependencyAnalyzerState.analyzeDependencies(...a),
+  formatCrossFileContext: jest.fn().mockReturnValue(''),
+  formatDependencySummary: jest.fn().mockReturnValue('')
+}))
+
+import {codeReview} from '../src/review'
+import {createGitHubExecutionContext} from '../src/platform/github-execution-context'
+import {Options} from '../src/options'
+import {Prompts} from '../src/prompts'
+
+function makeOptions(): Options {
+  return new Options(
+    false, // debug
+    false, // disableReview
+    true, // disableReleaseNotes
+    '0', // maxFiles
+    false, // reviewSimpleChanges
+    false, // reviewCommentLGTM
+    null, // pathFilters
+    '', // systemMessage
+    'gpt-5.4-nano',
+    'gpt-5.4-mini',
+    '0.0',
+    '3',
+    '120000',
+    '6',
+    '6',
+    'https://api.openai.com/v1',
+    'en-US',
+    true, // enableDependencyAnalysis — U5 专门测这条路径，必须打开
+    '50',
+    true,
+    true,
+    false // enableLintTools
+  )
+}
+
+function makeBot(response = 'ok'): any {
+  return {
+    chat: jest
+      .fn<() => Promise<[string, Record<string, unknown>, unknown[]]>>()
+      .mockResolvedValue([response, {}, []])
+  }
+}
+
+function makePullRequestPayload(overrides: Record<string, any> = {}): any {
+  return {
+    number: 42,
+    title: 'Add dependency analysis path',
+    body: 'body',
+    base: {sha: 'base-sha-0001'},
+    head: {sha: 'head-sha-0001'},
+    ...overrides
+  }
+}
+
+describe('review.ts 双轨一致性（execCtx vs context，Phase 0 依赖分析调用）', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.GITHUB_EVENT_NAME = 'pull_request'
+    mockContext.eventName = 'pull_request'
+    mockContext.actor = 'someone'
+    mockContext.payload = {action: 'opened', pull_request: makePullRequestPayload()}
+    mockContext.repo = {owner: 'octo', repo: 'demo'}
+
+    commenterState.getDescription.mockImplementation((body: string) => body ?? '')
+    commenterState.findCommentWithTag.mockResolvedValue(null)
+    commenterState.getAllCommitIds.mockResolvedValue([])
+    commenterState.addInProgressStatus.mockReturnValue('IN_PROGRESS')
+    commenterState.addReviewedCommitId.mockReturnValue('<!-- reviewed-commit-ids -->')
+
+    octokitState.compareCommits.mockResolvedValue({
+      data: {
+        files: [
+          {
+            filename: 'src/foo.ts',
+            status: 'modified',
+            patch: '@@ -1,3 +1,4 @@\n line1\n line2\n+added line\n line3'
+          }
+        ],
+        commits: [{sha: 'head-sha-0001'}]
+      }
+    })
+    octokitState.getContent.mockResolvedValue({
+      data: {type: 'file', content: Buffer.from('line1\nline2\nline3').toString('base64')}
+    })
+
+    repoTreeState.getRepoFileTree.mockResolvedValue([])
+    dependencyAnalyzerState.analyzeDependencies.mockResolvedValue({fileAnalyses: new Map()})
+  })
+
+  test('execCtx（真实工厂构造）与 context 对同一事件算出的 headSha 一致', () => {
+    // 前置断言：不依赖 codeReview 内部行为，直接验证两套构造路径本身的取值一致性——
+    // 这是"双轨"这个词真正的含义：两套独立代码路径读同一个底层事件，必须得到相同答案。
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.headSha).toBe(mockContext.payload.pull_request.head.sha)
+    expect(execCtx.baseSha).toBe(mockContext.payload.pull_request.base.sha)
+    expect(execCtx.changeRequestId).toBe(mockContext.payload.pull_request.number)
+  })
+
+  test('正常 PR 事件：getRepoFileTree/analyzeDependencies 收到的 ref/headSha 等于 execCtx.headSha 也等于 context.payload.pull_request.head.sha', async () => {
+    const execCtx = createGitHubExecutionContext()
+    expect(execCtx.headSha).toBe('head-sha-0001') // 前置确认 fixture 搭建正确
+
+    await codeReview(
+      execCtx,
+      makeBot('[TRIAGE]: APPROVED\nLGTM'),
+      makeBot(),
+      makeOptions(),
+      new Prompts('', '')
+    )
+
+    expect(repoTreeState.getRepoFileTree).toHaveBeenCalledTimes(1)
+    const [ref, project] = repoTreeState.getRepoFileTree.mock.calls[0] as any[]
+    expect(ref).toBe(execCtx.headSha)
+    expect(ref).toBe(mockContext.payload.pull_request.head.sha)
+    expect(project).toEqual({platform: 'github', owner: 'octo', repo: 'demo'})
+
+    expect(dependencyAnalyzerState.analyzeDependencies).toHaveBeenCalledTimes(1)
+    const depArgs = dependencyAnalyzerState.analyzeDependencies.mock.calls[0] as any[]
+    const headShaArgPosition = 5 // (filesAndChanges, repoFiles, options, concurrencyLimit, project, headSha, patchScans)
+    expect(depArgs[headShaArgPosition]).toBe(execCtx.headSha)
+    expect(depArgs[headShaArgPosition]).toBe(mockContext.payload.pull_request.head.sha)
+  })
+
+  test('execCtx.headSha 为空（评论触发场景）时，回退到 context.payload.pull_request.head.sha，不传出空字符串', async () => {
+    // 模拟评论触发命令场景：execCtx 来自评论事件（GitHub 工厂对 comment 事件固定
+    // 返回空字符串 headSha，见 github-execution-context.ts），但 codeReview 内部
+    // 的 context 仍然是完整的 PR 事件 payload（fromCommand 场景下 review.ts 会
+    // 自行通过 octokit 补齐 context.payload.pull_request，这里直接构造等价结果）。
+    const commentExecCtx: any = {
+      platform: 'github',
+      projectPath: 'octo/demo',
+      projectId: 'octo/demo',
+      changeRequestId: 42,
+      eventKind: 'comment_created',
+      actor: {login: 'alice', isBot: false},
+      baseSha: '',
+      headSha: '', // 关键：评论事件的 execCtx 天生没有 headSha
+      comment: {kind: 'top_level', id: 1},
+      raw: {}
+    }
+    expect(commentExecCtx.headSha).toBe('')
+
+    await codeReview(
+      commentExecCtx,
+      makeBot('[TRIAGE]: APPROVED\nLGTM'),
+      makeBot(),
+      makeOptions(),
+      new Prompts('', ''),
+      {source: 'command', mode: 'incremental'}
+    )
+
+    expect(repoTreeState.getRepoFileTree).toHaveBeenCalledTimes(1)
+    const [ref] = repoTreeState.getRepoFileTree.mock.calls[0] as any[]
+    // 空字符串是 falsy，|| 回退到 context 的值，不会把空字符串传给下游
+    expect(ref).toBe('head-sha-0001')
+    expect(ref).toBe(mockContext.payload.pull_request.head.sha)
+    expect(ref).not.toBe('')
+
+    const depArgs = dependencyAnalyzerState.analyzeDependencies.mock.calls[0] as any[]
+    expect(depArgs[5]).toBe('head-sha-0001')
+  })
+})

--- a/docs/tasks/gitlab-trigger-cli-design.md
+++ b/docs/tasks/gitlab-trigger-cli-design.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 # GitLab Trigger CLI 设计文档（EVENT-001 ~ EVENT-005）
 
-> **状态**：🚧 设计阶段（尚未开始代码开发）
+> **状态**：✅ 阶段一~三已完成（代码开发 + 单元测试 + 集成测试），见 PR #67；阶段四未开始
 > **优先级**：P0 —— GitHub↔GitLab 双平台兼容工作流 A 的第二个子任务（A5 的前半部分）
 > **依赖**：#62 / PR #63 交付的 `createGitLabExecutionContext()`（当前只存在于 `feat/execution-context` 分支，尚未合并 `main`）
 > **范围**：仅 `EVENT-001`~`EVENT-005`（CLI 入口 + payload 解析 + 结构校验 + 无关事件快速退出 + 日志脱敏）
@@ -331,6 +331,21 @@ __tests__/
 
 **本任务总计（阶段一~三）：约 24.5h（约 3 个工作日，单人估算）**
 
+### 8.5 实际完成状态（2026-07-27）
+
+阶段一~三已全部交付，见 PR #67（stacked on `feat/execution-context`）：
+
+| 阶段 | 交付文件 | 备注 |
+|:---|:---|:---|
+| 阶段一 G1-G4 | `src/gitlab-trigger-redact.ts`、`src/gitlab-trigger-validation.ts`、`src/gitlab-trigger.ts`、9 个 fixture JSON | 与第 7 节文件结构清单一致 |
+| 阶段二 U1 | `__tests__/gitlab-trigger-validation.test.ts`（12 用例，超过 ≥8 门槛） | 覆盖清单里列的全部场景 |
+| 阶段二 U2 | `__tests__/gitlab-trigger-redact.test.ts`（6 用例，超过 ≥5 门槛） | 覆盖清单里列的全部 4 种 token 形态 + 多重同现 + 无敏感内容 |
+| 阶段二 U3 / 阶段三 I1 | `__tests__/gitlab-trigger.test.ts`（8 用例） | 只 mock `fs.readFileSync`，`validateTriggerPayload`/`createGitLabExecutionContext`/`redact` 均为真实实现，兼顾 U3（分支覆盖）与 I1（真实 fixture 全流程）两个目标 |
+| 阶段三 I2 | 同上（文件读取失败路径注入 `glpat-` 字符串，断言输出不含明文） | 另一个 redact() 调用点（ExecutionContextError catch 分支）不接收动态 payload 内容，无泄漏面，未单独测 |
+| 阶段三 I3 | 已用 `grep` 确认零 GitHub 侧代码 import 新文件；`npm test` 556 passed/3 skipped 无新增失败 | — |
+
+**与文档建议的一处命名偏差**：第 7 节建议 CLI 集成测试命名为 `gitlab-trigger.characterization.test.ts`（呼应"新代码但用 fixture 驱动"的思路），实际交付为 `gitlab-trigger.test.ts`。内容和覆盖范围一致，仅文件名不同，如需对齐可后续重命名。
+
 ### 8.4 阶段四（后续排期，不计入本任务工时）
 
 - `EVENT-006`~`EVENT-021`：MR/Note Hook 具体业务规则（fork 拒绝、幂等键、命令触发、对话上下文）
@@ -342,12 +357,12 @@ __tests__/
 
 ## 9. 验收标准
 
-- [ ] CLI 能从本地文件路径正确读取并解析 `TRIGGER_PAYLOAD`（EVENT-001/002）
-- [ ] `validateTriggerPayload()` 对 project id / MR iid / source-target project id / note 必需字段的缺失均能正确识别并返回结构化原因（EVENT-003）
-- [ ] 无关事件（未知 `object_kind`、非 `merge_request`/`note`）触发 CLI 快速成功退出，不产生非零退出码，不调用任何模型/API（EVENT-004）
-- [ ] 所有错误路径的日志经过 `redact()` 处理，故意注入的 token 样式字符串不会明文出现在任何输出中（EVENT-005）
-- [ ] CLI 源文件不 import `@actions/core`/`@actions/github`（GitLab-only 独立运行前提，对齐 ARCH-015）
-- [ ] `npm test` 全量回归无新增失败，`GitHub-only` 场景不受影响
+- [x] CLI 能从本地文件路径正确读取并解析 `TRIGGER_PAYLOAD`（EVENT-001/002）
+- [x] `validateTriggerPayload()` 对 project id / MR iid / source-target project id / note 必需字段的缺失均能正确识别并返回结构化原因（EVENT-003）
+- [x] 无关事件（未知 `object_kind`、非 `merge_request`/`note`）触发 CLI 快速成功退出，不产生非零退出码，不调用任何模型/API（EVENT-004）
+- [x] 所有错误路径的日志经过 `redact()` 处理，故意注入的 token 样式字符串不会明文出现在任何输出中（EVENT-005）
+- [x] CLI 源文件不 import `@actions/core`/`@actions/github`（GitLab-only 独立运行前提，对齐 ARCH-015）
+- [x] `npm test` 全量回归无新增失败，`GitHub-only` 场景不受影响
 
 ---
 

--- a/src/gitlab-trigger-redact.ts
+++ b/src/gitlab-trigger-redact.ts
@@ -1,0 +1,18 @@
+/**
+ * gitlab-trigger-redact.ts - 错误日志脱敏（EVENT-005）
+ *
+ * 只处理字符串形态的错误信息，覆盖当前已知会出现在 gitlab-trigger 错误路径里的
+ * token 形态：GitLab PAT（glpat-）、Bearer token、URL query 中的 token 参数。
+ * 不是通用脱敏框架——覆盖 HTTP Header/环境变量/异常对象任意嵌套字段是 SEC-008
+ * 的范围，不在本任务内。
+ *
+ * 参考 docs/tasks/gitlab-trigger-cli-design.md 第 6 节。
+ */
+
+export function redact(input: string): string {
+  return input
+    .replace(/glpat-[A-Za-z0-9_-]+/g, 'glpat-***')
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer ***')
+    .replace(/([?&]token=)[^&\s]+/gi, '$1***')
+    .replace(/([?&]private_token=)[^&\s]+/gi, '$1***')
+}

--- a/src/gitlab-trigger-validation.ts
+++ b/src/gitlab-trigger-validation.ts
@@ -1,0 +1,61 @@
+/**
+ * gitlab-trigger-validation.ts - TRIGGER_PAYLOAD 结构校验（EVENT-003）
+ *
+ * `createGitLabExecutionContext` 已经校验了它需要的字段（object_attributes.iid、
+ * project、noteable_type 等），但不读取/校验 source_project_id/target_project_id
+ * ——这两个字段只用于 fork 检测（EVENT-010，本任务不实现拒绝逻辑）。本模块只负责
+ * "这些字段存不存在、类型对不对"的结构性校验，不做业务判断。
+ *
+ * 参考 docs/tasks/gitlab-trigger-cli-design.md 第 4 节。
+ */
+
+export interface TriggerPayloadValidation {
+  ok: boolean
+  reason?: string
+  sourceTargetMismatch?: boolean
+}
+
+export function validateTriggerPayload(
+  payload: unknown
+): TriggerPayloadValidation {
+  if (payload == null || typeof payload !== 'object') {
+    return {ok: false, reason: 'payload is not an object'}
+  }
+  const p = payload as Record<string, any>
+
+  if (p.object_kind !== 'merge_request' && p.object_kind !== 'note') {
+    // 未知 object_kind 的处理交给 createGitLabExecutionContext 的 unknown_event
+    // 分支（EVENT-004 快速退出），这里只做"是不是我们认识的两种事件"的粗过滤
+    return {ok: true}
+  }
+
+  const project = p.project
+  if (project?.id == null) {
+    return {ok: false, reason: 'missing project.id'}
+  }
+
+  if (p.object_kind === 'merge_request') {
+    const attrs = p.object_attributes
+    if (attrs?.iid == null) {
+      return {ok: false, reason: 'missing object_attributes.iid'}
+    }
+    if (attrs?.source_project_id == null || attrs?.target_project_id == null) {
+      return {ok: false, reason: 'missing source_project_id/target_project_id'}
+    }
+    return {
+      ok: true,
+      sourceTargetMismatch: attrs.source_project_id !== attrs.target_project_id
+    }
+  }
+
+  // note
+  const attrs = p.object_attributes
+  const mr = p.merge_request
+  if (attrs?.id == null) {
+    return {ok: false, reason: 'missing object_attributes.id'}
+  }
+  if (mr?.iid == null) {
+    return {ok: false, reason: 'missing merge_request.iid'}
+  }
+  return {ok: true}
+}

--- a/src/gitlab-trigger.ts
+++ b/src/gitlab-trigger.ts
@@ -1,0 +1,100 @@
+/**
+ * gitlab-trigger.ts - GitLab trigger CLI 入口（EVENT-001/002）
+ *
+ * 由 protected main 的 ai-review-trigger job 调用（未来，本任务不含该 CI 接入，
+ * 见 docs/tasks/gitlab-trigger-cli-design.md 阶段四）。从 file-type CI 变量
+ * TRIGGER_PAYLOAD 指向的文件路径读取原始事件 → 解析 JSON → 结构校验 →
+ * 构造 ExecutionContext → 打印摘要。
+ *
+ * 成功路径目前只打印日志，不调用模型、不写 GitLab note/discussion——真正的
+ * 审查/评论动作需要 GLAPI-*（GitLab REST API adapter），本任务不实现，见设计
+ * 文档第 3 节。
+ *
+ * 注：不 import @actions/core / @actions/github——GitLab-only 启动不得依赖
+ * GitHub 专有运行时（对齐 ARCH-015）。Logger 抽象本身是 ARCH-012~015 的范围，
+ * 本文件暂时直接用 console，等 Logger 任务落地后切换。
+ */
+import {readFileSync} from 'fs'
+import {createGitLabExecutionContext} from './platform/gitlab-execution-context'
+import {ExecutionContextError} from './platform/execution-context'
+import {validateTriggerPayload} from './gitlab-trigger-validation'
+import {redact} from './gitlab-trigger-redact'
+
+export async function run(): Promise<void> {
+  const payloadPath = process.env.TRIGGER_PAYLOAD
+  if (payloadPath == null || payloadPath === '') {
+    console.error('TRIGGER_PAYLOAD is not set')
+    process.exitCode = 1
+    return
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync(payloadPath, 'utf8')
+  } catch (e) {
+    console.error(`Failed to read TRIGGER_PAYLOAD file: ${redact(String(e))}`)
+    process.exitCode = 1
+    return
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    // 不打印 raw 内容本身——即使只是"JSON 解析失败"也可能包含敏感字段
+    console.error('TRIGGER_PAYLOAD content is not valid JSON')
+    process.exitCode = 1
+    return
+  }
+
+  const validation = validateTriggerPayload(parsed)
+  if (!validation.ok) {
+    console.error(`TRIGGER_PAYLOAD failed validation: ${validation.reason}`)
+    process.exitCode = 1
+    return
+  }
+  if (validation.sourceTargetMismatch) {
+    // EVENT-003 只做结构校验 + 记录；是否拒绝 fork MR 是 EVENT-010，不在本任务实现
+    console.log(
+      'Note: source_project_id != target_project_id (fork MR) — rejection logic is EVENT-010, not yet implemented'
+    )
+  }
+
+  let execCtx
+  try {
+    execCtx = createGitLabExecutionContext(parsed)
+  } catch (e) {
+    if (e instanceof ExecutionContextError && e.reason === 'unknown_event') {
+      // EVENT-004：无关事件快速成功退出
+      console.log(`Skipped: ${e.message}`)
+      return
+    }
+    console.error(
+      `Failed to build ExecutionContext: ${redact(
+        e instanceof Error ? e.message : String(e)
+      )}`
+    )
+    process.exitCode = 1
+    return
+  }
+
+  console.log(
+    `GitLab event validated: platform=${execCtx.platform} eventKind=${execCtx.eventKind} project=${execCtx.projectPath} mr=${execCtx.changeRequestId}`
+  )
+  // 真正的审查/评论动作需要 GLAPI-*（GitLab REST API adapter），本任务不实现。
+}
+
+// 不用顶层 await（同 main.ts 的既有原因：ts-jest 的 CommonJS 转译不支持顶层
+// await，会导致本文件无法被测试 import）。run() 内部已自行处理所有已知错误
+// 路径并设置 exitCode，理论上不会 reject；仍加 catch 兜底避免真正的意外异常
+// 变成未处理的 Promise rejection。
+void (async (): Promise<void> => {
+  try {
+    await run()
+  } catch (e) {
+    console.error(
+      `Unhandled error in gitlab-trigger run(): ${redact(String(e))}`
+    )
+    process.exitCode = 1
+  }
+})()


### PR DESCRIPTION
## Summary
延续 #64，实现 GitLab trigger CLI 入口，衔接 #62/PR #63 交付的 `createGitLabExecutionContext()`。

- `gitlab-trigger.ts`（EVENT-001/002）：CLI 入口，从 file-type `TRIGGER_PAYLOAD` 读取原始 payload → JSON 解析 → 结构校验 → `createGitLabExecutionContext` → 摘要日志。不 import `@actions/core`/`@actions/github`（对齐 ARCH-015）。
- `gitlab-trigger-validation.ts`（EVENT-003）：`validateTriggerPayload()`，校验 project id / MR iid / source-target project id / note 必需字段，未知 `object_kind` 放行给 ExecutionContext 层的 `unknown_event` 分支处理。
- `gitlab-trigger-redact.ts`（EVENT-005）：`redact()`，错误日志脱敏，覆盖 GitLab PAT（`glpat-`）、Bearer token、URL query 中的 `token`/`private_token` 四种形态。
- 补齐三份 Jest 自动化测试（原 commit 只用 ts-node 手动验证过场景，没有留下自动化覆盖）：`gitlab-trigger-redact.test.ts`、`gitlab-trigger-validation.test.ts`、`gitlab-trigger.test.ts`。

**范围内**：EVENT-001~005。
**明确排除**（见 #64）：`EVENT-006`~`EVENT-021`（fork 拒绝、幂等键、命令触发等业务规则）、`GLAPI-*`（GitLab REST API adapter）、`CMD-*`（GitLab 侧命令框架）、`BUILD-*`/`CI-*`（打包与 CI 接入）。

**已知遗留缺口**（本 PR 不修复，已单独建 Issue #66 跟踪）：GitLab note 事件 `action != create`（编辑/删除）时，当前实现按 `missing_required_field` fail closed（退出码 1），而不是像未知事件那样优雅跳过（退出码 0）。`gitlab-trigger.test.ts` 中显式断言了这个现状。

**Stacked PR**：base 为 `feat/execution-context`（PR #63，尚未合并 main），因为本 PR 依赖其交付的 `createGitLabExecutionContext()`。#63 合并 main 后本 PR 需 rebase 到 main。

## Test plan
- [x] `tsc --noEmit` 全绿
- [x] `npx jest --no-coverage`：556 passed / 3 skipped，仅 3 个与本分支无关、`origin/main` 上已存在的失败套件（`resolve.test.ts`/`resolve.integration.test.ts` 未解决合并冲突标记、`lint-tool-installer.test.ts` 缺失符号）
- [x] 新增 26 个测试用例覆盖 redact/validation/CLI 端到端

Closes #64（待合并后由维护者关闭 issue）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)