### PR TITLE
docs: GitLab MR Hook 业务规则设计文档（EVENT-006~013）

### DIFF
--- a/__tests__/fixtures/gitlab-mr-hook-merge-action.json
+++ b/__tests__/fixtures/gitlab-mr-hook-merge-action.json
@@ -1,0 +1,23 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "merged",
+    "action": "merge",
+    "last_commit": {"id": "head-sha-0001"}
+  },
+  "changes": {}
+}

--- a/__tests__/fixtures/gitlab-mr-hook-reopen.json
+++ b/__tests__/fixtures/gitlab-mr-hook-reopen.json
@@ -1,0 +1,23 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "reopen",
+    "last_commit": {"id": "head-sha-0001"}
+  },
+  "changes": {}
+}

--- a/__tests__/fixtures/gitlab-mr-hook-update-source-branch-only.json
+++ b/__tests__/fixtures/gitlab-mr-hook-update-source-branch-only.json
@@ -1,0 +1,29 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {"username": "alice", "name": "Alice"},
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo",
+    "web_url": "https://gitlab.example.com/octo/demo"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "source_branch": "feat/fixtures",
+    "target_branch": "main",
+    "source_project_id": 42,
+    "target_project_id": 42,
+    "state": "opened",
+    "action": "update",
+    "oldrev": "head-sha-0001",
+    "last_commit": {"id": "head-sha-0003-force-pushed"}
+  },
+  "changes": {
+    "source_branch": {
+      "previous": "feat/fixtures",
+      "current": "feat/fixtures"
+    }
+  }
+}

--- a/__tests__/gitlab-mr-hook-mapping.test.ts
+++ b/__tests__/gitlab-mr-hook-mapping.test.ts
@@ -1,0 +1,80 @@
+/**
+ * gitlab-mr-hook-mapping.test.ts — EVENT-006~009 既有映射的测试补强（M1）
+ *
+ * `mapMergeRequestAction()`（platform/gitlab-execution-context.ts）在
+ * feat/gitlab-trigger-cli 分支就已实现，本文件不新增业务代码，只通过公开的
+ * `createGitLabExecutionContext()` 补充此前未覆盖的边界场景：`changes` 缺失/
+ * 只含 source_branch（强制推送）/其他 action 值。
+ * 参考 docs/tasks/gitlab-mr-hook-design.md 第 3.1 节。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrReopen from './fixtures/gitlab-mr-hook-reopen.json'
+import mrUpdateSha from './fixtures/gitlab-mr-hook-update-sha.json'
+import mrUpdateMeta from './fixtures/gitlab-mr-hook-update-meta.json'
+import mrUpdateSourceBranchOnly from './fixtures/gitlab-mr-hook-update-source-branch-only.json'
+import mrMergeAction from './fixtures/gitlab-mr-hook-merge-action.json'
+
+describe('EVENT-006~009: MR action → eventKind 映射', () => {
+  test('EVENT-006 action=open → pr_opened', () => {
+    expect(createGitLabExecutionContext(mrOpen).eventKind).toBe('pr_opened')
+  })
+
+  test('EVENT-007 action=reopen → pr_reopened', () => {
+    expect(createGitLabExecutionContext(mrReopen).eventKind).toBe('pr_reopened')
+  })
+
+  test('EVENT-008 action=update 且 changes.last_commit 存在 → pr_synchronize', () => {
+    expect(createGitLabExecutionContext(mrUpdateSha).eventKind).toBe(
+      'pr_synchronize'
+    )
+  })
+
+  test('EVENT-008 action=update 且 changes 只含 source_branch（强制推送，last_commit 缺失）→ pr_synchronize', () => {
+    expect(
+      createGitLabExecutionContext(mrUpdateSourceBranchOnly).eventKind
+    ).toBe('pr_synchronize')
+  })
+
+  test('EVENT-009 action=update 且 changes 为空对象 → metadata_updated', () => {
+    const payload = {
+      ...mrOpen,
+      object_attributes: {
+        ...(mrOpen as any).object_attributes,
+        action: 'update'
+      },
+      changes: {}
+    }
+    expect(createGitLabExecutionContext(payload).eventKind).toBe(
+      'metadata_updated'
+    )
+  })
+
+  test('EVENT-009 action=update 且 changes 字段整体缺失（undefined）→ metadata_updated', () => {
+    const payload: any = {
+      ...mrOpen,
+      object_attributes: {
+        ...(mrOpen as any).object_attributes,
+        action: 'update'
+      }
+    }
+    delete payload.changes
+    expect(createGitLabExecutionContext(payload).eventKind).toBe(
+      'metadata_updated'
+    )
+  })
+
+  test('EVENT-009 action=update 且 changes 只含 title/labels → metadata_updated', () => {
+    expect(createGitLabExecutionContext(mrUpdateMeta).eventKind).toBe(
+      'metadata_updated'
+    )
+  })
+
+  test('action 为其他值（如 merge）→ unknown（不触发模型）', () => {
+    expect(createGitLabExecutionContext(mrMergeAction).eventKind).toBe(
+      'unknown'
+    )
+  })
+})

--- a/__tests__/gitlab-mr-hook-rules.test.ts
+++ b/__tests__/gitlab-mr-hook-rules.test.ts
@@ -1,0 +1,85 @@
+/**
+ * gitlab-mr-hook-rules.test.ts — checkForkMergeRequest/isHeadStale/
+ * buildMrIdempotencyKey 单元测试 + EVENT-011 不变量测试（M2/M3/M4/M5）
+ *
+ * 参考 docs/tasks/gitlab-mr-hook-design.md 第 3.2/3.3/3.4/3.5 节。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {
+  checkForkMergeRequest,
+  isHeadStale,
+  buildMrIdempotencyKey
+} from '../src/gitlab-mr-hook-rules'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+
+import mrOpen from './fixtures/gitlab-mr-hook-open.json'
+import mrFork from './fixtures/gitlab-mr-hook-fork.json'
+
+describe('EVENT-010: checkForkMergeRequest()', () => {
+  test('source_project_id !== target_project_id → isFork:true，附带 reason', () => {
+    const result = checkForkMergeRequest(99, 42)
+    expect(result.isFork).toBe(true)
+    expect(result.reason).toBe(
+      'source_project_id(99) !== target_project_id(42)'
+    )
+  })
+
+  test('source_project_id === target_project_id → isFork:false，reason 缺失', () => {
+    const result = checkForkMergeRequest(42, 42)
+    expect(result.isFork).toBe(false)
+    expect(result.reason).toBeUndefined()
+  })
+})
+
+describe('EVENT-011: fork 检测与 ExecutionContext 字段结构无关（不变量）', () => {
+  test('同项目 MR 与 fork MR 构造出的 ExecutionContext 字段结构（key 集合）完全一致', () => {
+    const same = createGitLabExecutionContext(mrOpen)
+    const fork = createGitLabExecutionContext(mrFork)
+
+    expect(Object.keys(same).sort()).toEqual(Object.keys(fork).sort())
+    expect(typeof same.projectPath).toBe(typeof fork.projectPath)
+    expect(typeof same.headSha).toBe(typeof fork.headSha)
+    expect(typeof same.actor.login).toBe(typeof fork.actor.login)
+    // fork 场景不会因为 source!=target 而跳过任何字段填充或改变类型
+    expect(fork.eventKind).toBe(same.eventKind)
+  })
+})
+
+describe('EVENT-012: isHeadStale()', () => {
+  test('两个 headSha 相同 → stale:false', () => {
+    const result = isHeadStale('sha-abc', 'sha-abc')
+    expect(result.stale).toBe(false)
+    expect(result.eventHeadSha).toBe('sha-abc')
+    expect(result.currentHeadSha).toBe('sha-abc')
+  })
+
+  test('两个 headSha 不同 → stale:true', () => {
+    const result = isHeadStale('sha-old', 'sha-new')
+    expect(result.stale).toBe(true)
+    expect(result.eventHeadSha).toBe('sha-old')
+    expect(result.currentHeadSha).toBe('sha-new')
+  })
+
+  test('是纯函数：不发起任何网络/文件 IO，仅比较传入的两个字符串', () => {
+    // 调用两次相同输入，结果应完全一致（无隐藏状态）
+    const a = isHeadStale('x', 'y')
+    const b = isHeadStale('x', 'y')
+    expect(a).toEqual(b)
+  })
+})
+
+describe('EVENT-013: buildMrIdempotencyKey()', () => {
+  test('格式为 gitlab:{project_id}:{mr_iid}:head:{head_sha}', () => {
+    expect(buildMrIdempotencyKey('42', 7, 'head-sha-0001')).toBe(
+      'gitlab:42:7:head:head-sha-0001'
+    )
+  })
+
+  test('不同 project_id/mr_iid/head_sha 组合产生不同的键（无碰撞）', () => {
+    const a = buildMrIdempotencyKey('42', 7, 'sha-1')
+    const b = buildMrIdempotencyKey('42', 8, 'sha-1')
+    const c = buildMrIdempotencyKey('43', 7, 'sha-1')
+    const d = buildMrIdempotencyKey('42', 7, 'sha-2')
+    expect(new Set([a, b, c, d]).size).toBe(4)
+  })
+})

--- a/__tests__/gitlab-trigger.test.ts
+++ b/__tests__/gitlab-trigger.test.ts
@@ -10,7 +10,14 @@
  * 并断言之，与 c9672be 提交信息中记录的已知缺口一致：这属于 EVENT-016/017
  * （Issue #66），本任务范围不修复，只需如实反映现状。
  */
-import {describe, expect, test, jest, beforeEach, afterEach} from '@jest/globals'
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  beforeEach,
+  afterEach
+} from '@jest/globals'
 
 import mrOpen from './fixtures/gitlab-mr-hook-open.json'
 import mrFork from './fixtures/gitlab-mr-hook-fork.json'
@@ -104,7 +111,9 @@ describe('gitlab-trigger.ts run()', () => {
     expect(errorSpy).not.toHaveBeenCalled()
     expect(process.exitCode).toBeUndefined()
     expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Skipped: Unsupported GitLab object_kind: pipeline')
+      expect.stringContaining(
+        'Skipped: Unsupported GitLab object_kind: pipeline'
+      )
     )
   })
 
@@ -120,21 +129,17 @@ describe('gitlab-trigger.ts run()', () => {
     expect(process.exitCode).toBe(1)
   })
 
-  test('fork MR（source!=target）→ 先打印 EVENT-010 提示，再打印成功摘要', async () => {
+  test('fork MR（source!=target）→ EVENT-010 fail closed 拒绝，退出码 1，不构造 ExecutionContext', async () => {
     process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
     fsState.readFileSync.mockReturnValue(JSON.stringify(mrFork))
 
     await runTrigger()
 
-    expect(process.exitCode).toBeUndefined()
-    expect(logSpy).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('fork MR')
-    )
-    expect(logSpy).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('mr=8')
-    )
+    expect(process.exitCode).toBe(1)
+    expect(logSpy).not.toHaveBeenCalled()
+    const message = errorSpy.mock.calls[0][0] as string
+    expect(message).toContain('Rejected: fork MR not supported')
+    expect(message).toContain('source_project_id(99) !== target_project_id(42)')
   })
 
   test('已知缺口：note action != create 时 fail closed 退出码 1（非优雅跳过，Issue #66 待修）', async () => {

--- a/docs/tasks/gitlab-mr-hook-design.md
+++ b/docs/tasks/gitlab-mr-hook-design.md
@@ -1,0 +1,195 @@
+---
+title: GitLab MR Hook 业务规则设计文档（EVENT-006~EVENT-013）
+sidebar_label: GitLab MR Hook 业务规则（双平台兼容）
+sidebar_position: 9
+---
+
+# GitLab MR Hook 业务规则设计文档（EVENT-006 ~ EVENT-013）
+
+> **状态**：设计中，尚未开发
+> **优先级**：P1 —— GitHub↔GitLab 双平台兼容工作流 A 的延续任务
+> **依赖**：`createGitLabExecutionContext()`（#62 / PR #63，`feat/execution-context` 分支，尚未合并 main）、`gitlab-trigger.ts`/`gitlab-trigger-validation.ts`（#64 / PR #67，`feat/gitlab-trigger-cli` 分支，尚未合并 main）
+> **跟踪 Issue**：[#69](https://github.com/CodesSentinels/ai-reviewer/issues/69)
+> **范围**：`EVENT-006`~`EVENT-013`（MR Hook 事件映射确认、fork 拒绝、写前 HEAD 重读的可测试纯函数、幂等键格式）
+> **不在本任务范围**：`GLAPI-*`（第7章，真正的 GitLab API 调用）、`STATE-005`（marker 持久化存储）、`EVENT-014`~`EVENT-021`（Note Hook，见 [gitlab-note-hook-design.md](./gitlab-note-hook-design.md)）
+
+---
+
+## 0. 参考文档
+
+- `docs/github-gitlab-compatibility-todo.md` 第 6.2 节（`EVENT-006`~`EVENT-013` 原始条目）
+- `docs/tasks/gitlab-trigger-cli-design.md`（EVENT-001~005，本任务的直接前置）
+- `docs/tasks/execution-context-design.md`（`ExecutionContext`/`createGitLabExecutionContext` 字段设计）
+- 仓库内记忆：`memory/execution_context_migration_project.md`、`memory/gitlab_only_doc_drift_risk.md`
+
+---
+
+## 1. 背景与现状
+
+`src/platform/gitlab-execution-context.ts` 的 `mapMergeRequestAction()` **已经**实现了 `EVENT-006`(MR 创建)/`EVENT-007`(reopen)/`EVENT-008`(HEAD 更新)/`EVENT-009`(纯元数据更新不触发模型) 的事件映射：
+
+```typescript
+function mapMergeRequestAction(attrs, changes): EventKind {
+  if (attrs.action === 'open') return 'pr_opened'
+  if (attrs.action === 'reopen') return 'pr_reopened'
+  if (attrs.action === 'update') {
+    const headChanged = changes?.last_commit != null || changes?.source_branch != null
+    return headChanged ? 'pr_synchronize' : 'metadata_updated'
+  }
+  return 'unknown'
+}
+```
+
+本任务对这四条的工作是**补充测试覆盖 + 边界场景确认**（比如 `changes` 字段缺失、`last_commit`/`source_branch` 只变了一个等情况），而不是新写映射逻辑。
+
+真正需要新代码的是 `EVENT-010~013`：
+
+1. **`EVENT-010`（fork 拒绝）**：`src/gitlab-trigger-validation.ts` 已经检测出 `source_project_id !== target_project_id`，但 `src/gitlab-trigger.ts` 目前只打日志，不 reject：
+
+   ```typescript
+   if (validation.sourceTargetMismatch) {
+     console.log('Note: source_project_id != target_project_id (fork MR) — rejection logic is EVENT-010, not yet implemented')
+   }
+   ```
+
+2. **`EVENT-011`（同项目 MR 仍按不可信数据处理）**：原则性要求，没有对应代码改动，靠测试固化。
+
+3. **`EVENT-012`（写前重读 HEAD）**：完全没有代码。真正"重新读取 GitLab MR 当前 HEAD"需要调用 GitLab API（`GLAPI-006`），本任务不实现网络调用。
+
+4. **`EVENT-013`（幂等键）**：完全没有代码。键的生成是纯函数，但键与 summary note marker 的比对需要 `GLAPI-007~009`（读取 note）和 `STATE-005`（marker 存储格式），本任务不实现这两块。
+
+---
+
+## 2. 目标（对应 TODO 条目）
+
+| 编号 | 内容 | 本设计如何满足 |
+|:---|:---|:---|
+| `EVENT-006` | 支持 MR 创建事件 | 第 3.1 节：补充测试，确认既有映射正确 |
+| `EVENT-007` | 支持 MR reopen 事件 | 同上 |
+| `EVENT-008` | 支持 MR HEAD SHA 更新事件 | 同上，含 `changes` 字段边界场景 |
+| `EVENT-009` | 纯元数据更新不调用模型 | 同上 |
+| `EVENT-010` | MVP 拒绝 fork MR | 第 3.2 节：`rejectForkMergeRequest()` |
+| `EVENT-011` | 同项目 MR 内容仍按不可信数据处理 | 第 3.3 节：不变量测试 |
+| `EVENT-012` | 写前重读 HEAD，不一致时退出 | 第 3.4 节：`isHeadStale()` 纯函数，真实读取延后到 GLAPI-006 |
+| `EVENT-013` | MR 自动审查幂等键 | 第 3.5 节：`buildMrIdempotencyKey()` |
+
+---
+
+## 3. 设计方案
+
+### 3.1 EVENT-006~009：既有映射的测试补强
+
+不新增业务代码。新增 `__tests__/gitlab-mr-hook-mapping.test.ts`，覆盖：
+
+- `action: 'open'` → `pr_opened`
+- `action: 'reopen'` → `pr_reopened`
+- `action: 'update'` + `changes.last_commit` 存在 → `pr_synchronize`
+- `action: 'update'` + `changes.source_branch` 存在（但 `last_commit` 缺失，比如强制推送场景）→ `pr_synchronize`
+- `action: 'update'` + `changes` 为空对象/`undefined` → `metadata_updated`
+- `action: 'update'` + `changes` 只含 `title`/`labels`/`assignees` → `metadata_updated`
+- `action` 为其他值（如 `close`/`merge`）→ `unknown`（不触发模型，走 `gitlab-trigger.ts` 现有的 `unknown_event` 优雅跳过路径）
+
+### 3.2 EVENT-010：拒绝 fork MR
+
+新增 `src/gitlab-mr-hook-rules.ts`：
+
+```typescript
+export interface ForkCheckResult {
+  isFork: boolean
+  reason?: string
+}
+
+export function checkForkMergeRequest(
+  sourceProjectId: number,
+  targetProjectId: number
+): ForkCheckResult {
+  if (sourceProjectId !== targetProjectId) {
+    return {
+      isFork: true,
+      reason: `source_project_id(${sourceProjectId}) !== target_project_id(${targetProjectId})`
+    }
+  }
+  return {isFork: false}
+}
+```
+
+`gitlab-trigger.ts` 在 `sourceTargetMismatch` 为真时改为：打印脱敏日志 + `process.exitCode = 1`（fail closed，语义上不同于"未知事件"的优雅跳过——fork MR 是一个需要人工关注的安全边界，不应该静默 exit 0）。
+
+> **待确认**：fork MR 的退出码语义（fail closed vs 优雅跳过）需要在 PR review 时和团队确认一次，因为这决定了 GitLab CI job 的失败通知频率——如果 fork MR 在实际使用中很常见，可能需要改成优雅跳过 + 告警而不是 job 失败。
+
+### 3.3 EVENT-011：不变量测试
+
+不新增业务代码（本身就没有做区分 source==target 的特殊逻辑）。新增测试用例，明确断言：无论 `sourceTargetMismatch` 是 true 还是 false，`createGitLabExecutionContext()` 后续的字段结构完全一致，不因为"同项目"就跳过任何字段校验。放在 `__tests__/gitlab-mr-hook-rules.test.ts` 里。
+
+### 3.4 EVENT-012：写前 HEAD 重读（纯函数部分）
+
+```typescript
+export interface HeadStaleCheck {
+  stale: boolean
+  eventHeadSha: string
+  currentHeadSha: string
+}
+
+export function isHeadStale(
+  eventHeadSha: string,
+  currentHeadSha: string
+): HeadStaleCheck {
+  return {
+    stale: eventHeadSha !== currentHeadSha,
+    eventHeadSha,
+    currentHeadSha
+  }
+}
+```
+
+`currentHeadSha` 的真实来源（调用 GitLab API 读取 MR 当前 HEAD）是 `GLAPI-006`，本任务不实现。本任务交付的是这个判断函数 + 调用点的**占位设计**：在设计文档里说明未来 `GLAPI-006` 就绪后，应该在"读取 diff/生成审查之前"调用一次 `isHeadStale()`，不一致则退出且不发布任何评论。
+
+### 3.5 EVENT-013：幂等键
+
+```typescript
+export function buildMrIdempotencyKey(
+  projectId: string,
+  mrIid: number,
+  headSha: string
+): string {
+  return `gitlab:${projectId}:${mrIid}:head:${headSha}`
+}
+```
+
+与 summary note 中 reviewed SHA marker 的比对属于 `STATE-005`，本任务只保证这个函数的输出格式符合 TODO 文档规定的 `gitlab:{project_id}:{mr_iid}:head:{head_sha}`。
+
+---
+
+## 4. 任务拆分
+
+| # | 任务 | 依赖 | 预估工时 |
+|:---|:---|:---:|:---:|
+| M1 | `EVENT-006~009` 映射测试补强 | 无 | 2h |
+| M2 | `checkForkMergeRequest()` + 接入 `gitlab-trigger.ts` | 无 | 3h |
+| M3 | `EVENT-011` 不变量测试 | M2 | 1.5h |
+| M4 | `isHeadStale()` 纯函数 + 单元测试 | 无 | 2h |
+| M5 | `buildMrIdempotencyKey()` + 单元测试 | 无 | 1.5h |
+| M6 | fixture 补充（fork MR 各种变体、`changes` 边界场景） | 无 | 2h |
+| M7 | 集成测试：CLI 全流程覆盖新增分支 | M2, M4, M5 | 3h |
+
+**合计：约 15h（约 2 个工作日）**
+
+---
+
+## 5. 验收标准
+
+- [ ] `EVENT-006~009` 的映射行为有显式测试覆盖，包含此前未覆盖的边界场景
+- [ ] fork MR 被 `gitlab-trigger.ts` 真正拒绝（非零退出），不再只是打日志
+- [ ] 同项目 MR 的字段处理路径与 fork MR 检测逻辑无关，测试固化
+- [ ] `isHeadStale()`/`buildMrIdempotencyKey()` 均为纯函数，不发起网络调用，单元测试覆盖率 100% 分支
+- [ ] `npm test` 全量回归无新增失败
+
+---
+
+## 6. 风险与未决问题
+
+| 风险/问题 | 说明 | 处理方式 |
+|:---|:---|:---|
+| fork MR 拒绝的退出码语义未定 | fail closed 还是优雅跳过，影响 CI 通知频率 | PR review 时与团队确认 |
+| `EVENT-012`/`EVENT-013` 无法端到端验证 | 依赖 `GLAPI-*`，本任务只能验证纯函数逻辑 | 在 PR 描述中明确说明，避免误以为已端到端可用 |
+| `changes` 字段的真实 Webhook 形态未经验证 | 与 `createGitLabExecutionContext` 的既有已知风险一致 | 标注待确认，真实环境接入时复核 |

--- a/docs/tasks/gitlab-mr-hook-design.md
+++ b/docs/tasks/gitlab-mr-hook-design.md
@@ -6,7 +6,7 @@ sidebar_position: 9
 
 # GitLab MR Hook 业务规则设计文档（EVENT-006 ~ EVENT-013）
 
-> **状态**：设计中，尚未开发
+> **状态**：✅ 已完成（代码开发 + 单元测试），见 `feat/gitlab-mr-hook-rules` 分支
 > **优先级**：P1 —— GitHub↔GitLab 双平台兼容工作流 A 的延续任务
 > **依赖**：`createGitLabExecutionContext()`（#62 / PR #63，`feat/execution-context` 分支，尚未合并 main）、`gitlab-trigger.ts`/`gitlab-trigger-validation.ts`（#64 / PR #67，`feat/gitlab-trigger-cli` 分支，尚未合并 main）
 > **跟踪 Issue**：[#69](https://github.com/CodesSentinels/ai-reviewer/issues/69)
@@ -178,11 +178,11 @@ export function buildMrIdempotencyKey(
 
 ## 5. 验收标准
 
-- [ ] `EVENT-006~009` 的映射行为有显式测试覆盖，包含此前未覆盖的边界场景
-- [ ] fork MR 被 `gitlab-trigger.ts` 真正拒绝（非零退出），不再只是打日志
-- [ ] 同项目 MR 的字段处理路径与 fork MR 检测逻辑无关，测试固化
-- [ ] `isHeadStale()`/`buildMrIdempotencyKey()` 均为纯函数，不发起网络调用，单元测试覆盖率 100% 分支
-- [ ] `npm test` 全量回归无新增失败
+- [x] `EVENT-006~009` 的映射行为有显式测试覆盖，包含此前未覆盖的边界场景
+- [x] fork MR 被 `gitlab-trigger.ts` 真正拒绝（非零退出），不再只是打日志
+- [x] 同项目 MR 的字段处理路径与 fork MR 检测逻辑无关，测试固化
+- [x] `isHeadStale()`/`buildMrIdempotencyKey()` 均为纯函数，不发起网络调用，单元测试覆盖率 100% 分支
+- [x] `npm test` 全量回归无新增失败
 
 ---
 

--- a/src/gitlab-mr-hook-rules.ts
+++ b/src/gitlab-mr-hook-rules.ts
@@ -1,0 +1,57 @@
+/**
+ * gitlab-mr-hook-rules.ts - GitLab MR Hook 业务规则（EVENT-010/012/013）
+ *
+ * 三个纯函数，不做任何文件/网络 IO：
+ * - checkForkMergeRequest()：EVENT-010，判断 MR 是否来自 fork（source_project_id
+ *   != target_project_id），供 gitlab-trigger.ts 决定是否 fail closed 拒绝。
+ * - isHeadStale()：EVENT-012，比较"事件里的 headSha"与"重新读取到的当前 headSha"
+ *   是否一致；真正重新读取 GitLab MR 当前 HEAD 属于 GLAPI-006，本函数只做比较。
+ * - buildMrIdempotencyKey()：EVENT-013，生成幂等键，格式为
+ *   `gitlab:{project_id}:{mr_iid}:head:{head_sha}`；与 summary note marker 的比对
+ *   属于 STATE-005，不在本文件范围。
+ *
+ * 参考 docs/tasks/gitlab-mr-hook-design.md 第 3.2/3.4/3.5 节。
+ */
+
+export interface ForkCheckResult {
+  isFork: boolean
+  reason?: string
+}
+
+export function checkForkMergeRequest(
+  sourceProjectId: number,
+  targetProjectId: number
+): ForkCheckResult {
+  if (sourceProjectId !== targetProjectId) {
+    return {
+      isFork: true,
+      reason: `source_project_id(${sourceProjectId}) !== target_project_id(${targetProjectId})`
+    }
+  }
+  return {isFork: false}
+}
+
+export interface HeadStaleCheck {
+  stale: boolean
+  eventHeadSha: string
+  currentHeadSha: string
+}
+
+export function isHeadStale(
+  eventHeadSha: string,
+  currentHeadSha: string
+): HeadStaleCheck {
+  return {
+    stale: eventHeadSha !== currentHeadSha,
+    eventHeadSha,
+    currentHeadSha
+  }
+}
+
+export function buildMrIdempotencyKey(
+  projectId: string,
+  mrIid: number,
+  headSha: string
+): string {
+  return `gitlab:${projectId}:${mrIid}:head:${headSha}`
+}

--- a/src/gitlab-trigger-validation.ts
+++ b/src/gitlab-trigger-validation.ts
@@ -3,8 +3,9 @@
  *
  * `createGitLabExecutionContext` 已经校验了它需要的字段（object_attributes.iid、
  * project、noteable_type 等），但不读取/校验 source_project_id/target_project_id
- * ——这两个字段只用于 fork 检测（EVENT-010，本任务不实现拒绝逻辑）。本模块只负责
- * "这些字段存不存在、类型对不对"的结构性校验，不做业务判断。
+ * ——这两个字段只用于 fork 检测。本模块只负责"这些字段存不存在、类型对不对"的结构性
+ * 校验，不做业务判断；实际的 fork 拒绝逻辑（EVENT-010）在
+ * `gitlab-mr-hook-rules.ts` 的 `checkForkMergeRequest()` + `gitlab-trigger.ts` 里。
  *
  * 参考 docs/tasks/gitlab-trigger-cli-design.md 第 4 节。
  */

--- a/src/gitlab-trigger.ts
+++ b/src/gitlab-trigger.ts
@@ -19,6 +19,7 @@ import {createGitLabExecutionContext} from './platform/gitlab-execution-context'
 import {ExecutionContextError} from './platform/execution-context'
 import {validateTriggerPayload} from './gitlab-trigger-validation'
 import {redact} from './gitlab-trigger-redact'
+import {checkForkMergeRequest} from './gitlab-mr-hook-rules'
 
 export async function run(): Promise<void> {
   const payloadPath = process.env.TRIGGER_PAYLOAD
@@ -54,10 +55,20 @@ export async function run(): Promise<void> {
     return
   }
   if (validation.sourceTargetMismatch) {
-    // EVENT-003 只做结构校验 + 记录；是否拒绝 fork MR 是 EVENT-010，不在本任务实现
-    console.log(
-      'Note: source_project_id != target_project_id (fork MR) — rejection logic is EVENT-010, not yet implemented'
+    // EVENT-010：fork MR 是需要人工关注的安全边界，fail closed 而非优雅跳过
+    // （区别于 unknown_event 的 exit 0 语义）——见 docs/tasks/gitlab-mr-hook-design.md 第 3.2 节。
+    const attrs = (parsed as Record<string, any>).object_attributes
+    const forkCheck = checkForkMergeRequest(
+      attrs.source_project_id,
+      attrs.target_project_id
     )
+    console.error(
+      `Rejected: fork MR not supported (MVP) — ${redact(
+        forkCheck.reason ?? ''
+      )}`
+    )
+    process.exitCode = 1
+    return
   }
 
   let execCtx


### PR DESCRIPTION
Closes #69

⚠️ **Stacked PR**：base 分支是 `feat/gitlab-trigger-cli`（PR #67），不是 `main`——本任务依赖 `gitlab-trigger.ts`/`gitlab-trigger-validation.ts`（#64/#67）以及更底层的 `createGitLabExecutionContext()`（#62/#63）。**必须等 #67（及其依赖的 #63）合并 main 后，把本 PR 的 base 改回 main 并 rebase**，再继续开发/合并。

## Summary

本 PR 目前只包含设计文档 `docs/tasks/gitlab-mr-hook-design.md`（EVENT-006~013 的方案、任务拆分、验收标准），代码实现在后续 commit 中补充。

## 范围

- `EVENT-006~009`：确认既有 `mapMergeRequestAction()` 映射，补测试
- `EVENT-010`：真正拒绝 fork MR（目前只打日志）
- `EVENT-011`：同项目 MR 不变量测试
- `EVENT-012`/`EVENT-013`：可测试的纯函数（`isHeadStale()`/`buildMrIdempotencyKey()`），真实 GitLab API 调用留给 `GLAPI-*`

## Test plan

- [x] `EVENT-006~009` 映射边界场景测试
- [x] fork MR 拒绝路径测试
- [x] `isHeadStale()`/`buildMrIdempotencyKey()` 单元测试
- [x] CLI 集成测试覆盖新增分支
- [x] `npm test` 全量回归无新增失败