### PR TITLE
docs: GitLab Note Hook 业务规则设计文档（EVENT-014~021，含 #66 修复）

### DIFF
--- a/__tests__/fixtures/gitlab-note-hook-non-mr.json
+++ b/__tests__/fixtures/gitlab-note-hook-non-mr.json
@@ -1,0 +1,21 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5004,
+    "note": "@ai-reviewer review",
+    "noteable_type": "Issue",
+    "action": "create"
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/fixtures/gitlab-note-hook-system.json
+++ b/__tests__/fixtures/gitlab-note-hook-system.json
@@ -1,0 +1,22 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {"username": "alice", "name": "Alice"},
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "path_with_namespace": "octo/demo"
+  },
+  "object_attributes": {
+    "id": 5003,
+    "note": "changed the description",
+    "noteable_type": "MergeRequest",
+    "action": "create",
+    "system": true
+  },
+  "merge_request": {
+    "iid": 7,
+    "title": "Add characterization fixtures",
+    "diff_head_sha": "head-sha-0001"
+  }
+}

--- a/__tests__/gitlab-execution-context.integration.test.ts
+++ b/__tests__/gitlab-execution-context.integration.test.ts
@@ -25,6 +25,8 @@ import mrFork from './fixtures/gitlab-mr-hook-fork.json'
 import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
 import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
 import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import noteSystem from './fixtures/gitlab-note-hook-system.json'
+import noteNonMr from './fixtures/gitlab-note-hook-non-mr.json'
 import unknownEvent from './fixtures/gitlab-unknown-event.json'
 import malformed from './fixtures/gitlab-malformed.json'
 
@@ -128,31 +130,54 @@ describe('I2: GitLab fixture 全字段完整性快照', () => {
       actor: {login: 'alice', isBot: false},
       baseSha: '',
       headSha: 'head-sha-0001',
-      comment: {kind: 'review_thread', id: 5002, threadId: 'abc123discussionid'},
+      comment: {
+        kind: 'review_thread',
+        id: 5002,
+        threadId: 'abc123discussionid'
+      },
       raw: noteDiscussion
     })
   })
 
   test.each([
-    {label: '未知 object_kind', fixture: unknownEvent, expectedReason: 'unknown_event'},
+    {
+      label: '未知 object_kind',
+      fixture: unknownEvent,
+      expectedReason: 'unknown_event'
+    },
     {
       label: '缺少 iid/source-target project',
       fixture: malformed,
       expectedReason: 'missing_required_field'
     },
     {
-      label: 'note action != create',
+      label: 'note action != create（EVENT-016/017，修复 Issue #66）',
       fixture: noteNonCreate,
-      expectedReason: 'missing_required_field'
+      expectedReason: 'ignorable_event'
+    },
+    {
+      label: 'note system=true（EVENT-017）',
+      fixture: noteSystem,
+      expectedReason: 'ignorable_event'
+    },
+    {
+      label: 'note noteable_type 非 MergeRequest（EVENT-017）',
+      fixture: noteNonMr,
+      expectedReason: 'ignorable_event'
     }
-  ] as const)('$label → 不产出 ExecutionContext，reason=$expectedReason', ({fixture, expectedReason}) => {
-    expect(() => createGitLabExecutionContext(fixture)).toThrow(ExecutionContextError)
-    try {
-      createGitLabExecutionContext(fixture)
-    } catch (e) {
-      expect((e as ExecutionContextError).reason).toBe(expectedReason)
+  ] as const)(
+    '$label → 不产出 ExecutionContext，reason=$expectedReason',
+    ({fixture, expectedReason}) => {
+      expect(() => createGitLabExecutionContext(fixture)).toThrow(
+        ExecutionContextError
+      )
+      try {
+        createGitLabExecutionContext(fixture)
+      } catch (e) {
+        expect((e as ExecutionContextError).reason).toBe(expectedReason)
+      }
     }
-  })
+  )
 
   test('全部 6 个成功场景的 ExecutionContext 都包含类型定义要求的全部必需字段', () => {
     const successfulFixtures = [

--- a/__tests__/gitlab-execution-context.test.ts
+++ b/__tests__/gitlab-execution-context.test.ts
@@ -2,9 +2,11 @@
  * gitlab-execution-context.test.ts — createGitLabExecutionContext() 单元测试（U2）
  *
  * 覆盖 MR open/reopen/update(HEAD变化)/update(仅元数据) + Note
- * create(top-level)/create(discussion回复)/非 create 动作/未知 object_kind，
- * 复用 __tests__/fixtures/ 下的共享 GitLab payload 样例（阶段一 G4 产出）。
- * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U2。
+ * create(top-level)/create(discussion回复)/非 create 动作/system note/非 MR
+ * note/未知 object_kind，复用 __tests__/fixtures/ 下的共享 GitLab payload 样例
+ * （阶段一 G4 产出，EVENT-016/017 补充了 system/non-mr 两个 fixture）。
+ * 参考 docs/tasks/execution-context-design.md 第 9.2 节 U2、
+ * docs/tasks/gitlab-note-hook-design.md 第 3.2 节（Issue #66 修复）。
  */
 import {describe, expect, test} from '@jest/globals'
 import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
@@ -17,6 +19,8 @@ import mrFork from './fixtures/gitlab-mr-hook-fork.json'
 import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
 import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
 import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import noteSystem from './fixtures/gitlab-note-hook-system.json'
+import noteNonMr from './fixtures/gitlab-note-hook-non-mr.json'
 import unknownEvent from './fixtures/gitlab-unknown-event.json'
 import malformed from './fixtures/gitlab-malformed.json'
 
@@ -39,7 +43,9 @@ describe('createGitLabExecutionContext()', () => {
   })
 
   test('payload 非对象（字符串）→ ExecutionContextError(missing_payload)', () => {
-    const e = getThrownError(() => createGitLabExecutionContext('not-an-object'))
+    const e = getThrownError(() =>
+      createGitLabExecutionContext('not-an-object')
+    )
     expect(e).toBeInstanceOf(ExecutionContextError)
     expect((e as ExecutionContextError).reason).toBe('missing_payload')
   })
@@ -79,7 +85,10 @@ describe('createGitLabExecutionContext()', () => {
   test('MR reopen → eventKind=pr_reopened', () => {
     const reopenPayload = {
       ...mrOpen,
-      object_attributes: {...(mrOpen as any).object_attributes, action: 'reopen'}
+      object_attributes: {
+        ...(mrOpen as any).object_attributes,
+        action: 'reopen'
+      }
     }
     const execCtx = createGitLabExecutionContext(reopenPayload)
     expect(execCtx.eventKind).toBe('pr_reopened')
@@ -107,7 +116,11 @@ describe('createGitLabExecutionContext()', () => {
     expect(execCtx.headSha).toBe('head-sha-0001') // merge_request.diff_head_sha
     expect(execCtx.baseSha).toBe('')
     expect(execCtx.actor).toEqual({login: 'alice', isBot: false})
-    expect(execCtx.comment).toEqual({kind: 'top_level', id: 5001, threadId: undefined})
+    expect(execCtx.comment).toEqual({
+      kind: 'top_level',
+      id: 5001,
+      threadId: undefined
+    })
   })
 
   test('Note create（discussion 回复）→ eventKind=review_comment_created，comment.kind=review_thread', () => {
@@ -121,10 +134,22 @@ describe('createGitLabExecutionContext()', () => {
     })
   })
 
-  test('Note action != create → ExecutionContextError(missing_required_field)（已知缺口，见 issue #66：应优雅跳过而非 fail closed，本任务不修复）', () => {
+  test('Note action != create → ExecutionContextError(ignorable_event)（修复 Issue #66：编辑/删除评论应优雅跳过而非 fail closed）', () => {
     const e = getThrownError(() => createGitLabExecutionContext(noteNonCreate))
     expect(e).toBeInstanceOf(ExecutionContextError)
-    expect((e as ExecutionContextError).reason).toBe('missing_required_field')
+    expect((e as ExecutionContextError).reason).toBe('ignorable_event')
+  })
+
+  test('Note system=true（系统事件note，如"changed the description"）→ ExecutionContextError(ignorable_event)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(noteSystem))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('ignorable_event')
+  })
+
+  test('Note noteable_type 不是 MergeRequest（如 Issue 上的评论）→ ExecutionContextError(ignorable_event)', () => {
+    const e = getThrownError(() => createGitLabExecutionContext(noteNonMr))
+    expect(e).toBeInstanceOf(ExecutionContextError)
+    expect((e as ExecutionContextError).reason).toBe('ignorable_event')
   })
 
   test('Note 缺少 merge_request.iid → ExecutionContextError(missing_required_field)', () => {
@@ -132,25 +157,16 @@ describe('createGitLabExecutionContext()', () => {
       object_kind: 'note',
       user: {username: 'alice'},
       project: {id: 42, path_with_namespace: 'octo/demo'},
-      object_attributes: {id: 5001, action: 'create', noteable_type: 'MergeRequest'}
+      object_attributes: {
+        id: 5001,
+        action: 'create',
+        noteable_type: 'MergeRequest'
+      }
       // merge_request 字段整个缺失
     }
     const e = getThrownError(() => createGitLabExecutionContext(payload))
     expect(e).toBeInstanceOf(ExecutionContextError)
     expect((e as ExecutionContextError).reason).toBe('missing_required_field')
-  })
-
-  test('Note noteable_type 不是 MergeRequest → ExecutionContextError(unknown_event)', () => {
-    const payload = {
-      object_kind: 'note',
-      user: {username: 'alice'},
-      project: {id: 42, path_with_namespace: 'octo/demo'},
-      object_attributes: {id: 5001, action: 'create', noteable_type: 'Issue'},
-      merge_request: {iid: 7}
-    }
-    const e = getThrownError(() => createGitLabExecutionContext(payload))
-    expect(e).toBeInstanceOf(ExecutionContextError)
-    expect((e as ExecutionContextError).reason).toBe('unknown_event')
   })
 
   test('isBot 恒为 false（GitLab MVP 用个人 PAT，无天然 bot 标记，见 EVENT-018）', () => {

--- a/__tests__/gitlab-note-hook-mapping.test.ts
+++ b/__tests__/gitlab-note-hook-mapping.test.ts
@@ -1,0 +1,39 @@
+/**
+ * gitlab-note-hook-mapping.test.ts — EVENT-014/015 结构性支持确认（M1 同款：
+ * 不新增业务代码，只确认既有 comment 字段映射足够支撑命令识别/路由）
+ *
+ * `ExecutionContext.comment` 字段（kind: 'top_level' | 'review_thread'）已经
+ * 能区分顶层 note 和 discussion note，真正的命令解析/路由复用 GitHub 侧既有的
+ * commands/dispatcher.ts + commands/parser.ts（不改动，见 EVENT-019 测试）。
+ * 参考 docs/tasks/gitlab-note-hook-design.md 第 3.1 节。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {createGitLabExecutionContext} from '../src/platform/gitlab-execution-context'
+
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
+
+describe('EVENT-014: 顶层 MR note → comment.kind=top_level, eventKind=comment_created', () => {
+  test('顶层 note（无 discussion_id）映射正确，且携带命令路由所需的全部字段', () => {
+    const execCtx = createGitLabExecutionContext(noteToplevel)
+
+    expect(execCtx.eventKind).toBe('comment_created')
+    expect(execCtx.comment?.kind).toBe('top_level')
+    expect(execCtx.comment?.threadId).toBeUndefined()
+    // 命令解析器（EVENT-019）只依赖评论正文，不依赖 ExecutionContext 本身，
+    // 这里确认原始 note body 保留在 raw 里，供 adapter 层取出后传给 parser
+    expect((execCtx.raw as any).object_attributes.note).toBe(
+      '@ai-reviewer review'
+    )
+  })
+})
+
+describe('EVENT-015: discussion note/reply → comment.kind=review_thread, eventKind=review_comment_created', () => {
+  test('discussion 回复（有 discussion_id）映射正确，携带对话上下文所需的 threadId', () => {
+    const execCtx = createGitLabExecutionContext(noteDiscussion)
+
+    expect(execCtx.eventKind).toBe('review_comment_created')
+    expect(execCtx.comment?.kind).toBe('review_thread')
+    expect(execCtx.comment?.threadId).toBe('abc123discussionid')
+  })
+})

--- a/__tests__/gitlab-note-hook-parser-reuse.test.ts
+++ b/__tests__/gitlab-note-hook-parser-reuse.test.ts
@@ -1,0 +1,55 @@
+/**
+ * gitlab-note-hook-parser-reuse.test.ts — EVENT-019 复用性确认（N8）
+ *
+ * 结论：`src/commands/parser.ts` 的 `parse(body, opts)` 只依赖评论正文字符串
+ * 和 `registeredCommands`/`botMentions`（均为纯值，见 constants.ts 的
+ * BOT_MENTIONS），不引用任何 GitHub 专有数据结构——可以直接对 GitLab note
+ * 的 `object_attributes.note` 字段调用，不需要解耦或改造。
+ *
+ * 已发现的 GitHub 专属假设（记录但不在本任务内解耦，属于未来 CMD-003 范围）：
+ * `commands/types.ts` 的 `CommandEventName` 类型固定为
+ * 'issue_comment' | 'pull_request_review_comment'（GitHub webhook 事件名），
+ * 被 `commands/dispatcher.ts`/`reaction.ts`/`early-reaction.ts`（命令路由/执行层，
+ * 不是 parser 本身）使用。GitLab note 事件（top-level / discussion note）要接入
+ * 这一层时，需要先给 CommandEventName 加上 GitLab 对应值或改为平台无关的
+ * EventKind，这是 CMD-* 阶段的工作，不在 EVENT-019 范围内。
+ *
+ * 参考 docs/tasks/gitlab-note-hook-design.md 第 3.4 节。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {parse, type ParserOptions} from '../src/commands/parser'
+
+import noteToplevel from './fixtures/gitlab-note-hook-toplevel.json'
+import noteDiscussion from './fixtures/gitlab-note-hook-discussion.json'
+
+const REGISTERED = new Set(['review', 'full review', 'resolve', 'summary'])
+const opts: ParserOptions = {registeredCommands: REGISTERED}
+
+describe('EVENT-019: commands/parser.ts 直接复用于 GitLab note body', () => {
+  test('顶层 note body（"@ai-reviewer review"）→ 命中 review 命令，无需任何改造', () => {
+    const body = (noteToplevel as any).object_attributes.note as string
+    const outcome = parse(body, opts)
+
+    expect(outcome.kind).toBe('command')
+    expect(outcome.command?.name).toBe('review')
+    expect(outcome.error).toBeUndefined()
+  })
+
+  test('discussion note body（自然语言提问，无命令）→ conversation fallback', () => {
+    const body = (noteDiscussion as any).object_attributes.note as string
+    const outcome = parse(body, opts)
+
+    expect(outcome.kind).toBe('conversation')
+  })
+
+  test('不含 bot mention 的 note body → none（跟 GitHub 侧行为一致）', () => {
+    const outcome = parse('just a regular MR comment', opts)
+    expect(outcome.kind).toBe('none')
+  })
+
+  test('GitLab note 命令语法非法参数 → 同 GitHub 侧一样返回 INVALID_ARGS', () => {
+    const outcome = parse('@ai-reviewer review $(rm -rf /)', opts)
+    expect(outcome.kind).toBe('command')
+    expect(outcome.error?.code).toBe('INVALID_ARGS')
+  })
+})

--- a/__tests__/gitlab-note-hook-rules.test.ts
+++ b/__tests__/gitlab-note-hook-rules.test.ts
@@ -1,0 +1,84 @@
+/**
+ * gitlab-note-hook-rules.test.ts — isSelfNote()/buildNoteIdempotencyKey() 单元
+ * 测试（EVENT-018/020）+ EVENT-021 重复投递去重测试（mock marker）
+ *
+ * 参考 docs/tasks/gitlab-note-hook-design.md 第 3.3/3.5/3.6 节。
+ */
+import {describe, expect, test} from '@jest/globals'
+import {
+  isSelfNote,
+  buildNoteIdempotencyKey
+} from '../src/gitlab-note-hook-rules'
+
+describe('EVENT-018: isSelfNote()', () => {
+  test('actorLogin 与 configuredPatUsername 相同（大小写一致）→ true', () => {
+    expect(isSelfNote('ai-reviewer-bot', 'ai-reviewer-bot')).toBe(true)
+  })
+
+  test('actorLogin 与 configuredPatUsername 大小写不同 → true（不区分大小写）', () => {
+    expect(isSelfNote('AI-Reviewer-Bot', 'ai-reviewer-bot')).toBe(true)
+  })
+
+  test('actorLogin 与 configuredPatUsername 不同 → false', () => {
+    expect(isSelfNote('alice', 'ai-reviewer-bot')).toBe(false)
+  })
+
+  test('空字符串 configuredPatUsername（未配置）不会误判真实用户为自己', () => {
+    expect(isSelfNote('alice', '')).toBe(false)
+  })
+})
+
+describe('EVENT-020: buildNoteIdempotencyKey()', () => {
+  test('格式为 gitlab:{project_id}:{mr_iid}:note:{note_id}:create', () => {
+    expect(buildNoteIdempotencyKey('42', 7, 5001)).toBe(
+      'gitlab:42:7:note:5001:create'
+    )
+  })
+
+  test('不同 project_id/mr_iid/note_id 组合产生不同的键（无碰撞）', () => {
+    const a = buildNoteIdempotencyKey('42', 7, 5001)
+    const b = buildNoteIdempotencyKey('42', 8, 5001)
+    const c = buildNoteIdempotencyKey('43', 7, 5001)
+    const d = buildNoteIdempotencyKey('42', 7, 5002)
+    expect(new Set([a, b, c, d]).size).toBe(4)
+  })
+})
+
+describe('EVENT-021: 重复投递不重复处理（mock marker store，非生产实现）', () => {
+  // 生产环境的持久化 marker 属于 STATE-005，这里只用内存 Set 验证幂等键设计
+  // 本身能正确支撑"去重"这个用途。
+  function createMockMarkerStore(): {
+    hasProcessed: (key: string) => boolean
+    markProcessed: (key: string) => void
+  } {
+    const seen = new Set<string>()
+    return {
+      hasProcessed: (key: string) => seen.has(key),
+      markProcessed: (key: string) => {
+        seen.add(key)
+      }
+    }
+  }
+
+  test('同一条 note 的 webhook 重复投递两次 → 第二次被识别为重复，不应再处理', () => {
+    const store = createMockMarkerStore()
+    const key = buildNoteIdempotencyKey('42', 7, 5001)
+
+    expect(store.hasProcessed(key)).toBe(false)
+    store.markProcessed(key)
+
+    // 模拟 webhook 重复投递：同一个 key 再次到达
+    expect(store.hasProcessed(key)).toBe(true)
+  })
+
+  test('不同 note（不同 note_id）触发不同的键 → 不会被误判为重复', () => {
+    const store = createMockMarkerStore()
+    const keyA = buildNoteIdempotencyKey('42', 7, 5001)
+    const keyB = buildNoteIdempotencyKey('42', 7, 5002)
+
+    store.markProcessed(keyA)
+
+    expect(store.hasProcessed(keyA)).toBe(true)
+    expect(store.hasProcessed(keyB)).toBe(false)
+  })
+})

--- a/__tests__/gitlab-trigger.test.ts
+++ b/__tests__/gitlab-trigger.test.ts
@@ -1,22 +1,31 @@
 /**
- * gitlab-trigger.test.ts — CLI 入口行为断言（EVENT-001/002/004）
+ * gitlab-trigger.test.ts — CLI 入口行为断言（EVENT-001/002/004，含 EVENT-016/017）
  *
  * c9672be 的提交信息称"已用 ts-node 对全部 7 种场景手动跑通验证"，但没有留下
  * 自动化测试——本文件把那些手动场景转成自动化用例，只 mock `fs.readFileSync`
  * （文件 IO 边界），validateTriggerPayload/createGitLabExecutionContext/redact
  * 全部用真实实现，贴近 CLI 实际的端到端行为。
  *
- * 覆盖的最后一个用例（note action != create）刻意保留当前的 fail-closed 行为
- * 并断言之，与 c9672be 提交信息中记录的已知缺口一致：这属于 EVENT-016/017
- * （Issue #66），本任务范围不修复，只需如实反映现状。
+ * note action != create 的用例此前刻意保留 fail-closed 行为并断言之
+ * （Issue #66 已知缺口）；本文件随 EVENT-016/017 的修复同步更新为断言
+ * 优雅跳过（exit 0），并新增 system note/非 MR note 两个同类场景。
  */
-import {describe, expect, test, jest, beforeEach, afterEach} from '@jest/globals'
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  beforeEach,
+  afterEach
+} from '@jest/globals'
 
 import mrOpen from './fixtures/gitlab-mr-hook-open.json'
 import mrFork from './fixtures/gitlab-mr-hook-fork.json'
 import malformed from './fixtures/gitlab-malformed.json'
 import unknownEvent from './fixtures/gitlab-unknown-event.json'
 import noteNonCreate from './fixtures/gitlab-note-hook-non-create.json'
+import noteSystem from './fixtures/gitlab-note-hook-system.json'
+import noteNonMr from './fixtures/gitlab-note-hook-non-mr.json'
 
 const fsState = {readFileSync: jest.fn<(...a: any[]) => string>()}
 jest.mock('fs', () => ({
@@ -104,7 +113,9 @@ describe('gitlab-trigger.ts run()', () => {
     expect(errorSpy).not.toHaveBeenCalled()
     expect(process.exitCode).toBeUndefined()
     expect(logSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Skipped: Unsupported GitLab object_kind: pipeline')
+      expect.stringContaining(
+        'Skipped: Unsupported GitLab object_kind: pipeline'
+      )
     )
   })
 
@@ -131,21 +142,43 @@ describe('gitlab-trigger.ts run()', () => {
       1,
       expect.stringContaining('fork MR')
     )
-    expect(logSpy).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('mr=8')
-    )
+    expect(logSpy).toHaveBeenNthCalledWith(2, expect.stringContaining('mr=8'))
   })
 
-  test('已知缺口：note action != create 时 fail closed 退出码 1（非优雅跳过，Issue #66 待修）', async () => {
+  test('EVENT-016/017（Issue #66 修复）：note action != create → 优雅跳过，退出码保持成功', async () => {
     process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
     fsState.readFileSync.mockReturnValue(JSON.stringify(noteNonCreate))
 
     await runTrigger()
 
-    expect(process.exitCode).toBe(1)
-    const message = errorSpy.mock.calls[0][0] as string
-    expect(message).toContain('Failed to build ExecutionContext')
-    expect(message).toContain('not a create action')
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBeUndefined()
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("note action is 'update', not 'create'")
+    )
+  })
+
+  test('EVENT-017：system note → 优雅跳过，退出码保持成功', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(noteSystem))
+
+    await runTrigger()
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBeUndefined()
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('system note'))
+  })
+
+  test('EVENT-017：非 MR note（noteable_type=Issue）→ 优雅跳过，退出码保持成功', async () => {
+    process.env.TRIGGER_PAYLOAD = '/tmp/payload.json'
+    fsState.readFileSync.mockReturnValue(JSON.stringify(noteNonMr))
+
+    await runTrigger()
+
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBeUndefined()
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('is not MergeRequest')
+    )
   })
 })

--- a/docs/tasks/gitlab-note-hook-design.md
+++ b/docs/tasks/gitlab-note-hook-design.md
@@ -1,0 +1,239 @@
+---
+title: GitLab Note Hook 业务规则设计文档（EVENT-014~EVENT-021，含 #66 修复）
+sidebar_label: GitLab Note Hook 业务规则（双平台兼容）
+sidebar_position: 10
+---
+
+# GitLab Note Hook 业务规则设计文档（EVENT-014 ~ EVENT-021）
+
+> **状态**：设计中，尚未开发
+> **优先级**：P1 —— GitHub↔GitLab 双平台兼容工作流 A 的延续任务
+> **依赖**：`createGitLabExecutionContext()`（#62 / PR #63）、`gitlab-trigger.ts`（#64 / PR #67）
+> **跟踪 Issue**：[#70](https://github.com/CodesSentinels/ai-reviewer/issues/70)（同时修复 [#66](https://github.com/CodesSentinels/ai-reviewer/issues/66)）
+> **范围**：`EVENT-014`~`EVENT-021`（Note Hook 命令识别的结构性支持、忽略事件分类修复、幂等键格式）
+> **不在本任务范围**：`CMD-*`（第9章，命令真正执行）、`STATE-005`（marker 持久化）、`GLAPI-*`（第7章）、`EVENT-006~013`（MR Hook，见 [gitlab-mr-hook-design.md](./gitlab-mr-hook-design.md)）
+
+> ⚠️ **协作说明**：Issue #66 的 assignee 是 `antonpanov-ux` 和 `linfei0211` 两人。本任务包含修复 #66，动手前需要先跟 `linfei0211` 对齐分工，不要单方面各自开工——具体分工结论应更新回本文档第 7 节。
+
+---
+
+## 0. 参考文档
+
+- `docs/github-gitlab-compatibility-todo.md` 第 6.3 节（`EVENT-014`~`EVENT-021` 原始条目）
+- Issue #66（GitLab note 编辑/删除事件被误判 fail closed 的完整复现记录）
+- `docs/tasks/gitlab-trigger-cli-design.md`（EVENT-001~005，本任务的直接前置）
+- `docs/tasks/gitlab-mr-hook-design.md`（EVENT-006~013，姊妹任务）
+- `src/commands/parser.ts`（GitHub 侧既有命令语法规则，`EVENT-019` 需要复用/对齐）
+
+---
+
+## 1. 背景与现状
+
+`src/platform/gitlab-execution-context.ts` 的 `buildFromNoteHook()` 现状：
+
+```typescript
+function buildFromNoteHook(p: Record<string, any>): ExecutionContext {
+  const attrs = p.object_attributes
+  const mr = p.merge_request
+  if (attrs == null || mr == null || attrs.action !== 'create') {
+    throw new ExecutionContextError(
+      'note payload missing required fields or not a create action',
+      'gitlab',
+      'missing_required_field'
+    )
+  }
+  if (attrs.noteable_type !== 'MergeRequest') {
+    throw new ExecutionContextError(
+      `Unsupported noteable_type: ${attrs.noteable_type}`,
+      'gitlab',
+      'unknown_event'
+    )
+  }
+  // ...
+  actor: {login: p.user?.username ?? '', isBot: false},
+  // ...
+}
+```
+
+两个已确认问题（详见 Issue #66）：
+
+1. `attrs.action !== 'create'`（编辑、删除已有评论）和"`attrs`/`mr` 字段真正缺失"共用同一个 `missing_required_field` reason，导致 `gitlab-trigger.ts` 对编辑/删除评论 fail closed（exit 1），而不是像 `unknown_event` 那样优雅跳过（exit 0）。
+2. `actor.isBot` 恒为 `false`——代码注释里写明"GitLab MVP 使用个人 PAT 身份评论，没有天然的 bot 账号标记"，真正的自反馈过滤（`EVENT-018`）还没做。
+
+`EVENT-014/015/019/020/021` 目前完全没有对应代码。
+
+---
+
+## 2. 目标（对应 TODO 条目）
+
+| 编号 | 内容 | 本设计如何满足 |
+|:---|:---|:---|
+| `EVENT-014` | 支持 MR 顶层 note 命令 | 第 3.1 节：命令识别的结构性支持 |
+| `EVENT-015` | 支持 discussion note/reply 命令和对话上下文 | 同上 |
+| `EVENT-016` | 只处理 `action=create` 的用户 note | 第 3.2 节：修复 #66，拆分 ignorable 事件原因 |
+| `EVENT-017` | 忽略编辑、删除、system note 和非 MR note | 同上，覆盖 system note / 非 MR note |
+| `EVENT-018` | 忽略 reviewer/PAT 账号自己的 note | 第 3.3 节：`isBot` 判断补全 |
+| `EVENT-019` | 不符合严格命令语法的文本不触发命令或模型 | 第 3.4 节：复用 `commands/parser.ts` |
+| `EVENT-020` | Note Hook 幂等键 | 第 3.5 节：`buildNoteIdempotencyKey()` |
+| `EVENT-021` | 重复投递不重复调用 | 第 3.6 节：基于 mock marker 的测试验证 |
+
+---
+
+## 3. 设计方案
+
+### 3.1 EVENT-014/015：命令识别的结构性支持
+
+`ExecutionContext.comment` 字段（`kind: 'top_level' | 'review_thread'`）已经能区分顶层 note 和 discussion note。本任务不新增字段，只确认：
+
+- 顶层 note（`kind: 'top_level'`）→ 对应 `eventKind: 'comment_created'`
+- discussion note（`kind: 'review_thread'`，`threadId` 有值）→ 对应 `eventKind: 'review_comment_created'`
+
+真正的命令解析/路由复用 GitHub 侧已有的 `src/commands/dispatcher.ts`/`src/commands/parser.ts`，本任务只保证 GitLab 的 `ExecutionContext` 能提供这两个函数需要的字段，不改动 dispatcher 本身（那属于 `CMD-*`，需要 `IGitPlatform` 才能真正执行命令产生的动作）。
+
+### 3.2 EVENT-016/017：修复 #66——拆分 ignorable 事件
+
+新增一个专门的 `ExecutionContextError.reason`：
+
+```typescript
+// execution-context.ts
+public readonly reason:
+  | 'missing_payload'
+  | 'malformed_payload'
+  | 'unknown_event'
+  | 'missing_required_field'
+  | 'ignorable_event'   // 新增：结构合法但业务上不需要处理（如非 create note）
+```
+
+`buildFromNoteHook()` 改为：
+
+```typescript
+function buildFromNoteHook(p: Record<string, any>): ExecutionContext {
+  const attrs = p.object_attributes
+  const mr = p.merge_request
+
+  // 结构缺失：真正的校验失败，fail closed
+  if (attrs == null || mr == null) {
+    throw new ExecutionContextError(
+      'note payload missing object_attributes/merge_request',
+      'gitlab',
+      'missing_required_field'
+    )
+  }
+
+  // 结构合法但不需要处理：优雅跳过（EVENT-016/017）
+  if (attrs.action !== 'create') {
+    throw new ExecutionContextError(
+      `note action is '${attrs.action}', not 'create' — ignorable`,
+      'gitlab',
+      'ignorable_event'
+    )
+  }
+  if (attrs.system === true) {
+    throw new ExecutionContextError(
+      'system note — ignorable',
+      'gitlab',
+      'ignorable_event'
+    )
+  }
+  if (attrs.noteable_type !== 'MergeRequest') {
+    throw new ExecutionContextError(
+      `noteable_type '${attrs.noteable_type}' is not MergeRequest — ignorable`,
+      'gitlab',
+      'ignorable_event'
+    )
+  }
+  // ... 其余不变
+}
+```
+
+`gitlab-trigger.ts` 的 catch 分支同时对 `unknown_event` 和 `ignorable_event` 做优雅跳过（exit 0），其余 reason 仍然 fail closed：
+
+```typescript
+if (e instanceof ExecutionContextError &&
+    (e.reason === 'unknown_event' || e.reason === 'ignorable_event')) {
+  console.log(`Skipped: ${e.message}`)
+  return
+}
+```
+
+> 覆盖 Issue #66 原始复现场景（`__tests__/fixtures/gitlab-note-hook-non-create.json`）+ 新增 system note / 非 MR note 两种 fixture。
+
+### 3.3 EVENT-018：忽略 reviewer/PAT 自己的 note
+
+`isBot` 目前恒为 `false`。本任务在 `buildFromNoteHook()` 之外新增一个独立函数（不放进 `ExecutionContext` 构造阶段，因为需要"已配置的 PAT 用户名"这个配置输入，而 `ExecutionContext` 构造阶段不应该依赖配置——这是刻意的架构边界，呼应 `ARCH-002` 的字段设计）：
+
+```typescript
+export function isSelfNote(actorLogin: string, configuredPatUsername: string): boolean {
+  return actorLogin.toLowerCase() === configuredPatUsername.toLowerCase()
+}
+```
+
+`configuredPatUsername` 的来源本任务先用环境变量占位（比如 `GITLAB_BOT_USERNAME`），等 `ConfigProvider`（4.2）就绪后再切换过去——这一点需要在 PR 描述里显式标注为临时方案。
+
+### 3.4 EVENT-019：命令语法校验
+
+不新写一套语法规则。确认 `src/commands/parser.ts` 导出的解析函数只依赖评论文本本身（不依赖 GitHub 特有的数据结构），可以直接给 GitLab note body 复用；如果发现有 GitHub 专属假设（比如依赖 `@mention` 的 GitHub 用户名格式），本任务需要记录下来但不一定要在本任务内解耦（那可能是 `CMD-003`"共用 parser、registry 和 handler 语义"的范围）。
+
+### 3.5 EVENT-020：Note Hook 幂等键
+
+```typescript
+export function buildNoteIdempotencyKey(
+  projectId: string,
+  mrIid: number,
+  noteId: number
+): string {
+  return `gitlab:${projectId}:${mrIid}:note:${noteId}:create`
+}
+```
+
+与 TODO 文档规定的格式 `gitlab:{project_id}:{mr_iid}:note:{note_id}:create` 完全对应。
+
+### 3.6 EVENT-021：重复投递测试
+
+不实现真实持久化。用一个内存 `Set<string>`（仅用于测试，不作为生产实现）模拟 marker 存储，验证：同一个 `buildNoteIdempotencyKey()` 输出出现两次时，第二次应该被判定为"已处理过"。生产环境的持久化实现属于 `STATE-005`。
+
+---
+
+## 4. 任务拆分
+
+| # | 任务 | 依赖 | 预估工时 |
+|:---|:---|:---:|:---:|
+| N1 | 与 `linfei0211` 对齐 #66 分工 | 无，最先做 | - |
+| N2 | 新增 `ignorable_event` reason + `buildFromNoteHook()` 重构 | N1 | 3h |
+| N3 | `gitlab-trigger.ts` catch 分支更新 | N2 | 1h |
+| N4 | fixture 补充（system note、非 MR note、非 create action） | N2 | 2h |
+| N5 | `isSelfNote()` + 环境变量占位接入 | 无 | 2h |
+| N6 | `buildNoteIdempotencyKey()` + 单元测试 | 无 | 1.5h |
+| N7 | `EVENT-021` 重复投递测试（mock marker） | N6 | 2h |
+| N8 | `EVENT-019` parser 复用性确认 + 记录发现的 GitHub 专属假设 | 无 | 2h |
+| N9 | 集成测试：CLI 全流程覆盖新增分支 | N2, N3, N4 | 3h |
+
+**合计：约 16.5h（约 2 个工作日，不含 N1 协调时间）**
+
+---
+
+## 5. 验收标准
+
+- [ ] Issue #66 复现场景（编辑/删除 note）改为 exit 0 优雅跳过
+- [ ] system note、非 MR note 同样优雅跳过，有 fixture 覆盖
+- [ ] `isSelfNote()` 有单元测试，且明确标注 PAT 用户名来源是临时环境变量方案
+- [ ] `buildNoteIdempotencyKey()` 输出格式与 TODO 文档一致
+- [ ] `commands/parser.ts` 复用性有结论（能直接复用 或 记录了需要解耦的 GitHub 专属假设）
+- [ ] `npm test` 全量回归无新增失败
+- [ ] 与 `linfei0211` 的分工已确认并记录
+
+---
+
+## 6. 风险与未决问题
+
+| 风险/问题 | 说明 | 处理方式 |
+|:---|:---|:---|
+| PAT 用户名配置来源是临时方案 | 等 `ConfigProvider`（4.2）就绪后需要切换 | PR 描述中显式标注，避免被当成最终方案合并 |
+| `EVENT-020`/`EVENT-021` 无法端到端验证 | 依赖 `STATE-005`/`GLAPI-*` | 只验证纯函数 + mock marker，PR 描述中说明边界 |
+| `commands/parser.ts` 可能有 GitHub 专属假设 | 影响 `EVENT-019`/未来 `CMD-003` 的复用范围 | 本任务先记录发现，不强行解耦 |
+
+---
+
+## 7. 与 linfei0211 的分工（协调结果占位）
+
+> 待补充：本任务开发前需要先和 `linfei0211` 确认谁负责 `ignorable_event` 的代码修改、谁负责测试覆盖，并把结论写回这里。

--- a/docs/tasks/gitlab-note-hook-design.md
+++ b/docs/tasks/gitlab-note-hook-design.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 # GitLab Note Hook 业务规则设计文档（EVENT-014 ~ EVENT-021）
 
-> **状态**：设计中，尚未开发
+> **状态**：⚠️ 代码开发 + 单元测试已完成（见 `feat/gitlab-note-hook-rules` 分支），但第 7 节的 `linfei0211` 分工对齐**尚未完成**——本任务在协作确认之前就已开工，见第 7 节说明，PR review 时需要标注
 > **优先级**：P1 —— GitHub↔GitLab 双平台兼容工作流 A 的延续任务
 > **依赖**：`createGitLabExecutionContext()`（#62 / PR #63）、`gitlab-trigger.ts`（#64 / PR #67）
 > **跟踪 Issue**：[#70](https://github.com/CodesSentinels/ai-reviewer/issues/70)（同时修复 [#66](https://github.com/CodesSentinels/ai-reviewer/issues/66)）
@@ -214,12 +214,12 @@ export function buildNoteIdempotencyKey(
 
 ## 5. 验收标准
 
-- [ ] Issue #66 复现场景（编辑/删除 note）改为 exit 0 优雅跳过
-- [ ] system note、非 MR note 同样优雅跳过，有 fixture 覆盖
-- [ ] `isSelfNote()` 有单元测试，且明确标注 PAT 用户名来源是临时环境变量方案
-- [ ] `buildNoteIdempotencyKey()` 输出格式与 TODO 文档一致
-- [ ] `commands/parser.ts` 复用性有结论（能直接复用 或 记录了需要解耦的 GitHub 专属假设）
-- [ ] `npm test` 全量回归无新增失败
+- [x] Issue #66 复现场景（编辑/删除 note）改为 exit 0 优雅跳过
+- [x] system note、非 MR note 同样优雅跳过，有 fixture 覆盖
+- [x] `isSelfNote()` 有单元测试，且明确标注 PAT 用户名来源是临时环境变量方案
+- [x] `buildNoteIdempotencyKey()` 输出格式与 TODO 文档一致
+- [x] `commands/parser.ts` 复用性有结论（能直接复用 或 记录了需要解耦的 GitHub 专属假设）
+- [x] `npm test` 全量回归无新增失败
 - [ ] 与 `linfei0211` 的分工已确认并记录
 
 ---
@@ -236,4 +236,9 @@ export function buildNoteIdempotencyKey(
 
 ## 7. 与 linfei0211 的分工（协调结果占位）
 
-> 待补充：本任务开发前需要先和 `linfei0211` 确认谁负责 `ignorable_event` 的代码修改、谁负责测试覆盖，并把结论写回这里。
+> ⚠️ **未完成**：本任务的代码开发（`ignorable_event` reason 拆分 + `buildFromNoteHook()` 重构 + 全部测试）已经在**未与 `linfei0211` 对齐分工**的情况下完成——按用户指示直接开工，跳过了本节要求的协调步骤。这不代表分工已确认，只代表实现已就绪可供协调后参考。
+>
+> 待办：PR 提交前仍需要和 `linfei0211` 确认：
+> 1. 这份实现是否与 `linfei0211` 已经在做/计划做的工作重复；
+> 2. 谁负责代码 review、谁负责后续 `STATE-005`/`ConfigProvider` 的对接；
+> 3. 确认后把结论更新回本节，再合并 PR。

--- a/src/gitlab-note-hook-rules.ts
+++ b/src/gitlab-note-hook-rules.ts
@@ -1,0 +1,31 @@
+/**
+ * gitlab-note-hook-rules.ts - GitLab Note Hook 业务规则（EVENT-018/020）
+ *
+ * 两个纯函数，不做任何文件/网络 IO：
+ * - isSelfNote()：EVENT-018，判断某条 note 是否由配置好的 PAT 账号自己发出
+ *   （用于反馈循环过滤）。故意不放进 ExecutionContext 构造阶段（execCtx.actor.isBot
+ *   恒为 false）——构造阶段不应依赖"已配置的 PAT 用户名"这个外部配置输入，
+ *   呼应 ARCH-002 的字段设计边界。`configuredPatUsername` 的来源本任务先用
+ *   环境变量占位（如 GITLAB_BOT_USERNAME），等 ConfigProvider 就绪后再切换，
+ *   这是刻意的临时方案，见 docs/tasks/gitlab-note-hook-design.md 第 3.3 节。
+ * - buildNoteIdempotencyKey()：EVENT-020，生成幂等键，格式为
+ *   `gitlab:{project_id}:{mr_iid}:note:{note_id}:create`；与 marker 存储的
+ *   对接属于 STATE-005，不在本文件范围。
+ *
+ * 参考 docs/tasks/gitlab-note-hook-design.md 第 3.3/3.5 节。
+ */
+
+export function isSelfNote(
+  actorLogin: string,
+  configuredPatUsername: string
+): boolean {
+  return actorLogin.toLowerCase() === configuredPatUsername.toLowerCase()
+}
+
+export function buildNoteIdempotencyKey(
+  projectId: string,
+  mrIid: number,
+  noteId: number
+): string {
+  return `gitlab:${projectId}:${mrIid}:note:${noteId}:create`
+}

--- a/src/gitlab-trigger.ts
+++ b/src/gitlab-trigger.ts
@@ -64,8 +64,13 @@ export async function run(): Promise<void> {
   try {
     execCtx = createGitLabExecutionContext(parsed)
   } catch (e) {
-    if (e instanceof ExecutionContextError && e.reason === 'unknown_event') {
-      // EVENT-004：无关事件快速成功退出
+    if (
+      e instanceof ExecutionContextError &&
+      (e.reason === 'unknown_event' || e.reason === 'ignorable_event')
+    ) {
+      // EVENT-004：完全不认识的事件（unknown_event）；EVENT-016/017：认识但
+      // 业务上不需要处理的事件，如 note 编辑/删除、system note（ignorable_event，
+      // 修复 Issue #66）。两者都优雅跳过，不应 fail closed。
       console.log(`Skipped: ${e.message}`)
       return
     }

--- a/src/platform/execution-context.ts
+++ b/src/platform/execution-context.ts
@@ -81,7 +81,16 @@ export interface ExecutionContext {
   raw: unknown
 }
 
-/** payload 缺失、格式错误或事件未知时抛出（ARCH-006 fail-closed） */
+/**
+ * payload 缺失、格式错误或事件未知时抛出（ARCH-006 fail-closed）。
+ *
+ * `ignorable_event` 与 `unknown_event` 都应被调用方（gitlab-trigger.ts）当作
+ * 优雅跳过（exit 0）处理，区别在于语义：`unknown_event` 是"完全不认识的
+ * object_kind"，`ignorable_event` 是"认识这个事件类型，但结构合法且业务上
+ * 明确不需要处理"（如 note 编辑/删除、system note、非 MR note，见 EVENT-016/017、
+ * Issue #66）。拆分出独立 reason 是为了和真正的校验失败（`missing_required_field`，
+ * 仍应 fail closed）区分开。
+ */
 export class ExecutionContextError extends Error {
   constructor(
     message: string,
@@ -93,6 +102,7 @@ export class ExecutionContextError extends Error {
       | 'malformed_payload'
       | 'unknown_event'
       | 'missing_required_field'
+      | 'ignorable_event'
   ) {
     super(message)
     this.name = 'ExecutionContextError'

--- a/src/platform/gitlab-execution-context.ts
+++ b/src/platform/gitlab-execution-context.ts
@@ -8,8 +8,9 @@
  * 本文件的函数"，不需要重新设计字段映射。
  *
  * `isBot` 恒为 false：GitLab MVP 使用个人 PAT 身份评论，没有天然的 bot 账号标记；
- * 真正的自反馈过滤需要将 actor.login 与配置好的 PAT 用户名比较，属于 EVENT-018
- * （GitLab adapter 消费层任务），不在 ExecutionContext 构造阶段判断。
+ * 真正的自反馈过滤需要将 actor.login 与配置好的 PAT 用户名比较（EVENT-018，
+ * 见 `gitlab-note-hook-rules.ts` 的 `isSelfNote()`），故意不放进 ExecutionContext
+ * 构造阶段判断——构造阶段不应依赖外部配置输入（呼应 ARCH-002 的字段设计边界）。
  *
  * GitLab Webhook 字段映射依据 GitLab 官方 Webhook events 文档整理，尚未经真实
  * Webhook 验证（ai-reviewer-test 项目尚未接入），EVENT-002 对接真实环境时需要
@@ -81,18 +82,38 @@ function buildFromMergeRequestHook(p: Record<string, any>): ExecutionContext {
 function buildFromNoteHook(p: Record<string, any>): ExecutionContext {
   const attrs = p.object_attributes
   const mr = p.merge_request
-  if (attrs == null || mr == null || attrs.action !== 'create') {
+
+  // 结构缺失：真正的校验失败，fail closed（区别于下面的 ignorable_event）
+  if (attrs == null || mr == null) {
     throw new ExecutionContextError(
-      'note payload missing required fields or not a create action',
+      'note payload missing object_attributes/merge_request',
       'gitlab',
       'missing_required_field'
     )
   }
+
+  // 结构合法但业务上不需要处理：优雅跳过（EVENT-016/017，修复 Issue #66——
+  // 此前这三种情形跟"字段真正缺失"共用 missing_required_field，导致
+  // gitlab-trigger.ts 对编辑/删除评论等 fail closed 而非优雅跳过）
+  if (attrs.action !== 'create') {
+    throw new ExecutionContextError(
+      `note action is '${attrs.action}', not 'create' — ignorable`,
+      'gitlab',
+      'ignorable_event'
+    )
+  }
+  if (attrs.system === true) {
+    throw new ExecutionContextError(
+      'system note — ignorable',
+      'gitlab',
+      'ignorable_event'
+    )
+  }
   if (attrs.noteable_type !== 'MergeRequest') {
     throw new ExecutionContextError(
-      `Unsupported noteable_type: ${attrs.noteable_type}`,
+      `noteable_type '${attrs.noteable_type}' is not MergeRequest — ignorable`,
       'gitlab',
-      'unknown_event'
+      'ignorable_event'
     )
   }
   return {


### PR DESCRIPTION
Closes #70
Related to #66

⚠️ **Stacked PR**：base 分支是 `feat/gitlab-trigger-cli`（PR #67），不是 `main`。**必须等 #67（及其依赖的 #63）合并 main 后，把本 PR 的 base 改回 main 并 rebase**，再继续开发/合并。

⚠️ **协作提醒**：本 PR 包含 #66 的修复方案，#66 的 assignee 是 `antonpanov-ux` 和 `linfei0211` 两人。开发前需要先对齐分工，见设计文档第 7 节（目前是占位，待补充）。

## Summary

本 PR 目前只包含设计文档 `docs/tasks/gitlab-note-hook-design.md`（EVENT-014~021 的方案、#66 修复方案、任务拆分、验收标准），代码实现在后续 commit 中补充。

## 范围

- `EVENT-014/015`：命令识别的结构性支持（复用 `ExecutionContext.comment` 字段）
- `EVENT-016/017`：修复 #66——新增 `ExecutionContextError.reason: 'ignorable_event'`，把"非 create action"/system note/非 MR note 从 fail-closed 路径中拆出来，优雅跳过
- `EVENT-018`：`isSelfNote()`（PAT 用户名来源暂用环境变量占位，等 ConfigProvider 就绪后切换）
- `EVENT-019`：确认 `commands/parser.ts` 的复用性
- `EVENT-020/021`：Note Hook 幂等键格式 + mock marker 验证重复投递

## Test plan

- [x] Issue #66 复现场景改为 exit 0（回归测试）
- [x] system note / 非 MR note fixture 覆盖
- [x] `isSelfNote()`/`buildNoteIdempotencyKey()` 单元测试
- [x] CLI 集成测试覆盖新增分支
- [x] `npm test` 全量回归无新增失败
