### PR TITLE
fix: sync-to-gitlab 触发分支改为 develop，main 暂不处理

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -3,13 +3,13 @@ name: Sync to GitLab
 on:
   push:
     branches:
-      - main
+      - develop
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to sync to GitLab (must exist with the same name on both remotes)'
         required: true
-        default: 'main'
+        default: 'develop'
 
 jobs:
   sync:
@@ -19,12 +19,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.branch || 'main' }}
+          ref: ${{ github.event.inputs.branch || 'develop' }}
 
       - name: Push to GitLab
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-          SYNC_BRANCH: ${{ github.event.inputs.branch || 'main' }}
+          SYNC_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
         run: |
           git remote add gitlab https://oauth2:${GITLAB_TOKEN}@gitlab.com/CodesSentinels/ai-reviewer.git
           # 不用 --force：GitLab 侧分支可能存在 GitHub 这边没有的提交（团队成员
@@ -32,6 +32,8 @@ jobs:
           # 如果 GitLab 侧已经领先/分叉，这一步会失败并让 job 报红，倒逼人工先把
           # GitLab 的提交合并回 GitHub，而不是被单向镜像悄悄覆盖掉。
           #
-          # workflow_dispatch 的 branch 输入用于手动同步 main 以外的分支（如
-          # develop）；自动的 push-to-main 触发路径行为不变。
+          # 触发分支改为 develop（原为 main）：main 两边已分叉，暂不处理，
+          # 避免这个自动化 job 在下次 main push 时又报红/或误操作。develop
+          # 目前两边一致，一路保持普通 push 即可安全维持同步。
+          # workflow_dispatch 的 branch 输入仍可用于手动同步其他分支。
           git push gitlab "HEAD:refs/heads/${SYNC_BRANCH}"


### PR DESCRIPTION
## Summary
- `sync-to-gitlab.yml` 的自动 push 触发分支从 `main` 改为 `develop`（同时 `workflow_dispatch` 默认值同步改为 `develop`）。
- `main` 暂时不再自动同步——GitLab `main` 目前领先/分叉（有 GitHub 没有的提交），继续用它做自动触发容易在下次 main push 时再次报红或需要人工介入，先搁置到与 GitLab 侧协调完再处理。
- `develop` 目前两边内容一致（byte-identical），继续用非 force push 自动维持同步是安全的。

## 关联变更
- 取消了 PR #78（全 CI 端双向自动合并 workflow）的方案，改回这个更简单的单向镜像思路：GitHub develop push → 自动推到 GitLab develop（非 force，分叉时失败不覆盖）。

## Test plan
- [ ] Review diff（改动很小，只有触发分支和默认值）
- [ ] 合并后下次 push 到 develop 时确认 Actions 自动触发且成功