### PR TITLE
fix: sync-to-gitlab 恢复 --force + main 纳入自动触发（main 分支同款）

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -3,6 +3,7 @@ name: Sync to GitLab
 on:
   push:
     branches:
+      - main
       - develop
   workflow_dispatch:
     inputs:
@@ -19,20 +20,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.branch || 'develop' }}
+          # push 事件：github.event.inputs.branch 为空，回退到 github.ref_name
+          # （实际被 push 的分支，main 或 develop 都适用）。
+          # workflow_dispatch：用显式传入的 branch 输入，覆盖触发时的 ref。
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Push to GitLab
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-          SYNC_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
+          SYNC_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
         run: |
           git remote add gitlab https://oauth2:${GITLAB_TOKEN}@gitlab.com/CodesSentinels/ai-reviewer.git
           # 恢复 --force：团队内部约定之后不再直接在 GitLab 上做任何代码改动，
           # GitHub 是唯一真相源，GitLab 只是单向镜像目标。之前去掉 --force 是
           # 因为当时 GitLab 侧确实存在独立提交（团队成员直接在 GitLab 开发），
-          # 那个前提已经不再成立，所以不需要再用"普通 push 失败以防覆盖"的
-          # 保护措施。
+          # 那个前提已经不再成立。
           #
-          # 触发分支改为 develop（原为 main）：main 两边已分叉，暂不处理。
-          # workflow_dispatch 的 branch 输入仍可用于手动同步其他分支。
+          # main 和 develop 都纳入自动触发；workflow_dispatch 的 branch 输入
+          # 仍可用于手动同步其他分支。
           git push gitlab "HEAD:refs/heads/${SYNC_BRANCH}" --force

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -27,13 +27,12 @@ jobs:
           SYNC_BRANCH: ${{ github.event.inputs.branch || 'develop' }}
         run: |
           git remote add gitlab https://oauth2:${GITLAB_TOKEN}@gitlab.com/CodesSentinels/ai-reviewer.git
-          # 不用 --force：GitLab 侧分支可能存在 GitHub 这边没有的提交（团队成员
-          # 直接在 GitLab 上开发）。force-push 会静默丢弃那些提交。改为普通 push——
-          # 如果 GitLab 侧已经领先/分叉，这一步会失败并让 job 报红，倒逼人工先把
-          # GitLab 的提交合并回 GitHub，而不是被单向镜像悄悄覆盖掉。
+          # 恢复 --force：团队内部约定之后不再直接在 GitLab 上做任何代码改动，
+          # GitHub 是唯一真相源，GitLab 只是单向镜像目标。之前去掉 --force 是
+          # 因为当时 GitLab 侧确实存在独立提交（团队成员直接在 GitLab 开发），
+          # 那个前提已经不再成立，所以不需要再用"普通 push 失败以防覆盖"的
+          # 保护措施。
           #
-          # 触发分支改为 develop（原为 main）：main 两边已分叉，暂不处理，
-          # 避免这个自动化 job 在下次 main push 时又报红/或误操作。develop
-          # 目前两边一致，一路保持普通 push 即可安全维持同步。
+          # 触发分支改为 develop（原为 main）：main 两边已分叉，暂不处理。
           # workflow_dispatch 的 branch 输入仍可用于手动同步其他分支。
-          git push gitlab "HEAD:refs/heads/${SYNC_BRANCH}"
+          git push gitlab "HEAD:refs/heads/${SYNC_BRANCH}" --force


### PR DESCRIPTION
## Summary
把 PR #80（develop 分支的同款修复）cherry-pick 到 main：
- 恢复 `--force`：团队约定 GitHub 是唯一真相源，不再直接在 GitLab 改代码。
- 触发分支加回 `main`（与 `develop` 一起自动同步）。
- 修复 bug：`ref`/`SYNC_BRANCH` 之前固定回退到字面量 `'develop'`，push 到 main 时会错误地去同步 develop。改为 `inputs.branch || github.ref_name`，push 事件下正确取实际被 push 的分支。

## ⚠️ 注意
合并后下次 push 到 main（或手动 dispatch branch=main）会 **force-push 覆盖 GitLab main**，包括 GitLab 侧此前独立存在的提交（Doge Mo 的若干 docs commit）。这是本次操作的预期结果——团队已确认之后 GitHub 是唯一真相源。

## Test plan
- [ ] Review diff（与 #80 内容一致，cherry-pick 过来的）
- [ ] 合并后验证 main/develop 两边都能正确自动同步到 GitLab 对应分支