### PR TITLE
feat: 单向发布 Workflow 加固（SYNC-001~009）

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -17,10 +17,34 @@ on:
         required: true
         default: 'develop'
 
+# SYNC-003：按目标分支分组，同一分支的旧同步在新一次触发后被取消，
+# 避免旧同步比新同步跑得慢、完成顺序颠倒导致新内容被旧内容覆盖。
+# main/develop 各自的分组独立，互不取消。
+concurrency:
+  group: sync-to-gitlab-${{ github.event.inputs.branch || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # SYNC-002/008：workflow_dispatch 的 branch 输入是自由文本，push 触发器
+      # 虽然已经用 on.push.branches 限制了 main/develop，但手动触发没有同等
+      # 限制——不校验的话，任何人都能用 workflow_dispatch 把仓库里任意分支强推
+      # 到 GitLab 同名分支。放在 checkout/拿到 GITLAB_TOKEN 之前，校验失败时
+      # 后续步骤都不会执行。
+      - name: Validate branch allowlist
+        env:
+          SYNC_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
+        run: |
+          case "$SYNC_BRANCH" in
+            main|develop)
+              echo "ok: $SYNC_BRANCH is in sync allowlist" ;;
+            *)
+              echo "REFUSED: '$SYNC_BRANCH' is not in the sync allowlist (main, develop)" >&2
+              exit 1 ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -42,5 +66,26 @@ jobs:
           # 那个前提已经不再成立。
           #
           # main 和 develop 都纳入自动触发；workflow_dispatch 的 branch 输入
-          # 仍可用于手动同步其他分支。
+          # 仍可用于手动同步 main/develop（上面的白名单校验已限制取值范围）。
           git push gitlab "HEAD:refs/heads/${SYNC_BRANCH}" --force
+
+      # SYNC-004：git push 命令本身成功退出，不代表 GitLab 那端真的收到了这次
+      # 推送的内容——网络问题、GitLab 侧 hook 拒绝、并发覆盖都可能让这个假设
+      # 不成立。回读 GitLab 当前这个分支的 HEAD，跟本地刚推送的 commit 比对，
+      # 是第 12 章 ai_review_trigger 信任链（CI-013）的上游保证：那边校验
+      # bundle 记录的 source commit 等于当前 CI_COMMIT_SHA，前提就是这一步
+      # 保证 GitLab main 上的内容确实等于这次同步推送的内容。
+      - name: Verify GitLab received the pushed SHA
+        env:
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+          SYNC_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
+        run: |
+          LOCAL_SHA=$(git rev-parse HEAD)
+          GITLAB_SHA=$(curl -sf --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "https://gitlab.com/api/v4/projects/CodesSentinels%2Fai-reviewer/repository/branches/${SYNC_BRANCH}" \
+            | jq -r '.commit.id')
+          if [ "$GITLAB_SHA" != "$LOCAL_SHA" ]; then
+            echo "SYNC FAILED: GitLab $SYNC_BRANCH is at $GITLAB_SHA, expected $LOCAL_SHA" >&2
+            exit 1
+          fi
+          echo "OK: GitLab $SYNC_BRANCH confirmed at $LOCAL_SHA"

--- a/__tests__/arch-guard.test.ts
+++ b/__tests__/arch-guard.test.ts
@@ -470,3 +470,29 @@ describe('GH-015: 平台状态 marker 不跨平台读写', () => {
     expect(gitlabTrigger).toMatch(/setStateNamespace\(\s*'gitlab'\s*\)/)
   })
 })
+
+describe('SYNC-009: GitLab 运行代码不得读取同步 Token', () => {
+  const allFiles = collectTsFiles(SRC)
+
+  // GITLAB_TOKEN 是 .github/workflows/sync-to-gitlab.yml 专用的、持有 GitLab
+  // 写权限的同步凭据，只应存在于 GitHub Actions secret 里；GitLab-only 运行时
+  // 用的是完全不同的 GITLAB_PAT/CI_JOB_TOKEN（见 gitlab-trigger.ts
+  // resolveGitLabCredential()）。src/ 里任何地方出现 GITLAB_TOKEN 字符串，
+  // 都意味着有代码在尝试读取本该只属于同步 workflow 的凭据。
+  test('src/ 下不出现 GITLAB_TOKEN（与 GITLAB_PAT/CI_JOB_TOKEN 是两个不同凭据）', () => {
+    const violations: string[] = []
+    for (const f of allFiles) {
+      const code = fs.readFileSync(f, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*/g, '')
+      if (/\bGITLAB_TOKEN\b/.test(code)) {
+        violations.push(path.relative(SRC, f).replace(/\\/g, '/'))
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  test('gitlab-trigger.ts 确实使用的是 GITLAB_PAT/CI_JOB_TOKEN（防止两个凭据名字都被删掉导致上一条测试空跑）', () => {
+    const content = fs.readFileSync(path.join(SRC, 'gitlab-trigger.ts'), 'utf8')
+    expect(content).toContain('GITLAB_PAT')
+    expect(content).toContain('CI_JOB_TOKEN')
+  })
+})

--- a/__tests__/workflow-security.test.ts
+++ b/__tests__/workflow-security.test.ts
@@ -294,3 +294,72 @@ describe('SEC-002/004/005: 双执行面的分工与产物流向', () => {
     expect(lintStep['continue-on-error']).toBe(true)
   })
 })
+
+describe('SYNC-001~009: sync-to-gitlab.yml 加固', () => {
+  const wf = workflows.find(w => w.name === 'sync-to-gitlab.yml') as Workflow
+
+  test('存在 sync-to-gitlab.yml', () => {
+    expect(wf).toBeDefined()
+  })
+
+  test('SYNC-003：配置了 concurrency，且按目标分支分组', () => {
+    expect(wf.doc.concurrency).toBeDefined()
+    expect(wf.doc.concurrency.group).toContain('github.event.inputs.branch')
+    expect(wf.doc.concurrency.group).toContain('github.ref_name')
+  })
+
+  test('SYNC-002/008：workflow_dispatch 的 branch 输入前有白名单校验 step', () => {
+    for (const [, job] of jobsOf(wf.doc)) {
+      const steps = stepsOf(job)
+      const validateIdx = steps.findIndex((s: any) => /allowlist/i.test(s.name ?? ''))
+      expect(validateIdx).toBeGreaterThanOrEqual(0)
+
+      const validateScript = String(steps[validateIdx].run ?? '')
+      expect(validateScript).toMatch(/main\|develop/)
+
+      // 校验必须排在 checkout/push 之前，不能形同虚设
+      const checkoutIdx = steps.findIndex((s: any) =>
+        String(s.uses ?? '').startsWith('actions/checkout')
+      )
+      expect(checkoutIdx).toBeGreaterThan(validateIdx)
+    }
+  })
+
+  test('SYNC-004：push 之后存在一个回读 GitLab HEAD 并比对 SHA 的 step', () => {
+    for (const [, job] of jobsOf(wf.doc)) {
+      const steps = stepsOf(job)
+      const pushIdx = steps.findIndex((s: any) => String(s.run ?? '').includes('git push gitlab'))
+      const verifyIdx = steps.findIndex((s: any) =>
+        String(s.run ?? '').includes('repository/branches')
+      )
+      expect(pushIdx).toBeGreaterThanOrEqual(0)
+      expect(verifyIdx).toBeGreaterThan(pushIdx)
+      expect(String(steps[verifyIdx].run)).toContain('LOCAL_SHA')
+    }
+  })
+
+  test('SYNC-002：目标仓库 URL 是固定字面量，不是变量插值', () => {
+    expect(codeOf(wf.raw)).toContain('gitlab.com/CodesSentinels/ai-reviewer.git')
+    expect(codeOf(wf.raw)).not.toMatch(/gitlab\.com\/\$\{/)
+  })
+
+  test('SYNC-005/006：sync-to-gitlab.yml 只有一个 job，内部没有 needs（file 内没有可失败的依赖链）', () => {
+    const jobs = jobsOf(wf.doc)
+    expect(jobs).toHaveLength(1)
+    for (const [, job] of jobs) {
+      expect(job.needs).toBeUndefined()
+    }
+  })
+
+  test('SYNC-005/006：sync-to-gitlab.yml 与 openai-review.yml 互不跨文件触发（无 workflow_run 指向对方）', () => {
+    const reviewWf = workflows.find(w => w.name === 'openai-review.yml') as Workflow
+    expect(triggersOf(wf.doc).workflow_run).toBeUndefined()
+    expect(triggersOf(reviewWf.doc).workflow_run).toBeUndefined()
+  })
+
+  test('SYNC-008：自动触发（on.push）只监听 main/develop，不含 tag', () => {
+    const pushTrigger = wf.doc.on?.push ?? wf.doc[true as unknown as string]?.push
+    expect(pushTrigger.branches).toEqual(['main', 'develop'])
+    expect(pushTrigger.tags).toBeUndefined()
+  })
+})

--- a/docs/github-gitlab-compatibility-todo.md
+++ b/docs/github-gitlab-compatibility-todo.md
@@ -757,15 +757,32 @@
 
 ## 13. 单向发布 Workflow 开发
 
-- [ ] `SYNC-001` 审查并加固 `.github/workflows/sync-to-gitlab.yml`。
-- [ ] `SYNC-002` 固定源/目标仓库与 `main` 分支，禁止不受控 ref 和目标 URL。
-- [ ] `SYNC-003` 增加 concurrency，防止旧同步覆盖新提交。
-- [ ] `SYNC-004` push 后自动比较 GitHub/GitLab `main` SHA。
-- [ ] `SYNC-005` 同步失败时 job 失败，但不得影响 GitHub Action 审查 workflow。
-- [ ] `SYNC-006` 防止 GitLab pipeline 反向触发 GitHub 写入或形成同步循环。
-- [ ] `SYNC-007` 重复同步保持幂等。
-- [ ] `SYNC-008` tag 和其他分支默认不同步；代码中使用显式白名单。
-- [ ] `SYNC-009` GitLab reviewer 运行代码中不得读取同步 Token 或调用 GitHub。
+> **状态**：⚠️ 配置 + 结构性测试已完成，**未经真实同步回放验证**（GitHub Issue
+> [#105](https://github.com/CodesSentinels/ai-reviewer/issues/105) 跟踪，汇总见
+> Issue [#75](https://github.com/CodesSentinels/ai-reviewer/issues/75)；设计文档
+> `docs/tasks/gitlab-sync-hardening-design.md`）。在已有的
+> `.github/workflows/sync-to-gitlab.yml`（目标仓库 URL 固定字面量、自动触发只
+> 监听 `main`/`develop`、与 `openai-review.yml` 完全独立不互相触发，均已确认
+> 满足）基础上，新增三步：分支白名单校验（堵住 `workflow_dispatch` 此前可同步
+> 任意分支的漏洞）、`concurrency`（按目标分支分组、`cancel-in-progress`）、push
+> 后回读 GitLab HEAD 并比对 SHA。`__tests__/workflow-security.test.ts` 新增 7
+> 项结构性断言，`__tests__/arch-guard.test.ts` 新增 `GITLAB_TOKEN`（同步专用
+> 凭据）不得出现在 `src/` 的守卫（`SYNC-009`）。⚠️ 已知缺口：`SYNC-004` 新增的
+> `curl`/`jq` 调用 GitLab REST API 的逻辑，本地/CI 均没有真实有效的
+> `GITLAB_TOKEN` 和 `ai-reviewer-test` 项目可供回放，只做了脚本走查和 YAML 结
+> 构断言，未经真实执行验证；GitLab 项目的 Protected Branch 保护规则（拒绝直接
+> push/MR merge）是项目配置项，本任务无法在代码层面体现。接入真实项目前不应
+> 把本章视为"已验收"。
+
+- [x] `SYNC-001` 审查并加固 `.github/workflows/sync-to-gitlab.yml`。
+- [x] `SYNC-002` 固定源/目标仓库与 `main` 分支，禁止不受控 ref 和目标 URL。
+- [x] `SYNC-003` 增加 concurrency，防止旧同步覆盖新提交。
+- [x] `SYNC-004` push 后自动比较 GitHub/GitLab `main` SHA。
+- [x] `SYNC-005` 同步失败时 job 失败，但不得影响 GitHub Action 审查 workflow。
+- [x] `SYNC-006` 防止 GitLab pipeline 反向触发 GitHub 写入或形成同步循环。
+- [x] `SYNC-007` 重复同步保持幂等。
+- [x] `SYNC-008` tag 和其他分支默认不同步；代码中使用显式白名单。
+- [x] `SYNC-009` GitLab reviewer 运行代码中不得读取同步 Token 或调用 GitHub。
 
 ---
 

--- a/docs/tasks/gitlab-sync-hardening-design.md
+++ b/docs/tasks/gitlab-sync-hardening-design.md
@@ -1,0 +1,145 @@
+# 单向发布 Workflow 加固设计文档（SYNC-001 ~ SYNC-009）
+
+## 0. 参考文档
+
+- [兼容开发 TODO List](../github-gitlab-compatibility-todo.md) 第 13 章
+- [双平台兼容实施方案](../github-to-gitlab-migration-plan.md) §1.8 Mirror Repository、§2.4 `sync-to-gitlab.yml`
+- [GitLab CI 开发设计文档](./gitlab-ci-design.md)（消费方——`ai_review_trigger` 信任的 `main` 内容由本任务加固的同步链路产出）
+
+---
+
+## 1. 背景与现状
+
+`docs/github-gitlab-compatibility-todo.md` 第 13 章"单向发布 Workflow 开发"（`SYNC-001~009`）此前全部未开始。`.github/workflows/sync-to-gitlab.yml` 已存在（历史上经过 PR #77 加了 `workflow_dispatch` 手动同步任意分支的能力，PR 见 `dc5817f`/`caaacc4`），当前内容：
+
+```yaml
+on:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+    inputs:
+      branch: {required: true, default: 'develop'}   # 无校验，可填任意分支名
+
+jobs:
+  sync:
+    steps:
+      - checkout（fetch-depth: 0，ref 取 inputs.branch 或 github.ref_name）
+      - git push gitlab "HEAD:refs/heads/${SYNC_BRANCH}" --force   # 硬编码目标仓库 URL
+```
+
+实施方案 §1.8/§2.4 已经把方向定死："GitHub → GitLab 单向同步，长期保留并加固；GitLab `main` 是受保护运行镜像，不接受直接 push/MR 合并，不反向写回 GitHub"。本任务是"加固"，不是重新设计同步机制或换成 GitLab Pull Mirror（那是文档里提到的备选方案，本任务不涉及）。
+
+### 已确认满足的部分
+
+- 目标仓库 URL 是硬编码字面量（`https://oauth2:${GITLAB_TOKEN}@gitlab.com/CodesSentinels/ai-reviewer.git`），不是可被外部输入覆盖的变量——`SYNC-002` 的"固定目标 URL"部分已满足。
+- 自动触发（`on.push`）只监听 `main`/`develop`，不含 tag——`SYNC-008` 的自动触发路径已满足。
+- 本 workflow 与 `openai-review.yml` 是完全独立的两个文件，互不 `needs`/触发，同步失败不可能连带影响审查 workflow——`SYNC-005` 结构性已满足。
+- 只做单向 push，没有任何读取 GitLab 状态并写回 GitHub 的代码路径——`SYNC-006` 结构性已满足。
+- `GITLAB_TOKEN`（同步专用、有 GitLab 写权限）只在这个 workflow 里以 secret 形式出现；`src/`（GitLab-only 运行代码）用的是完全不同的 `GITLAB_PAT`/`CI_JOB_TOKEN`，两者不重合——`SYNC-009` 结构性已满足，第 4 节加一条测试钉死。
+
+### 确认的真实缺口
+
+- **`SYNC-003`（concurrency）**：完全缺失，workflow 里没有 `concurrency:` 键。连续两次 push 到同一分支时，两次同步 job 可能并发跑，`--force` push 的完成顺序不保证跟触发顺序一致，存在旧同步覆盖新提交的竞态。
+- **`SYNC-004`（push 后 SHA 比对）**：完全缺失，`git push --force` 执行完就算成功，没有任何一步去确认 GitLab 那边真的收到了这次推送的内容。
+- **`SYNC-008`（分支白名单，`workflow_dispatch` 路径）**：`on.push.branches` 限制了自动触发，但 `workflow_dispatch.inputs.branch` 是自由文本输入，没有任何校验——手动触发时可以填任意分支名，把仓库里的任何分支（不只是 `main`/`develop`）强推到 GitLab 上同名分支，绕开了"只同步受信任分支"这个约束。
+
+---
+
+## 2. 目标（对应 TODO 条目）
+
+| 编号 | 内容 | 本设计如何满足 |
+|:---|:---|:---|
+| `SYNC-001` | 审查并加固 workflow | 本文档整体 |
+| `SYNC-002` | 固定源/目标仓库与 `main` 分支 | 第 3.1 节（补齐分支白名单） |
+| `SYNC-003` | concurrency，防止旧同步覆盖新提交 | 第 3.2 节 |
+| `SYNC-004` | push 后自动比较 SHA | 第 3.3 节 |
+| `SYNC-005` | 同步失败不影响审查 workflow | 已满足，第 4 节测试锁定 |
+| `SYNC-006` | 防止反向触发/同步循环 | 已满足，第 4 节测试锁定 |
+| `SYNC-007` | 重复同步幂等 | 已满足（force push 同 SHA 是 no-op），第 4 节测试锁定 |
+| `SYNC-008` | tag/其他分支默认不同步，显式白名单 | 第 3.1 节 |
+| `SYNC-009` | GitLab reviewer 代码不读同步 Token | 第 4 节测试锁定 |
+
+---
+
+## 3. 设计方案
+
+### 3.1 SYNC-002/008：分支白名单，堵住 `workflow_dispatch` 的自由输入
+
+在 checkout 之前新增一步，`push`/`workflow_dispatch` 两条触发路径统一校验：
+
+```yaml
+- name: Validate branch allowlist
+  env:
+    SYNC_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
+  run: |
+    case "$SYNC_BRANCH" in
+      main|develop) echo "ok: $SYNC_BRANCH is in sync allowlist" ;;
+      *)
+        echo "REFUSED: '$SYNC_BRANCH' is not in the sync allowlist (main, develop)" >&2
+        exit 1
+        ;;
+    esac
+```
+
+放在拿到 `GITLAB_TOKEN` 之前——白名单校验失败时 job 直接退出，后续 checkout/push 步骤都不会执行，`workflow_dispatch` 不再能同步任意分支。`push` 触发路径本来就只有 `main`/`develop` 能走到这一步，这条检查对它是纯粹的冗余保险，不改变行为。
+
+### 3.2 SYNC-003：concurrency
+
+```yaml
+concurrency:
+  group: sync-to-gitlab-${{ github.event.inputs.branch || github.ref_name }}
+  cancel-in-progress: true
+```
+
+按目标分支分组——`main`、`develop` 各自的同步互不影响，同一个分支如果短时间内触发了两次（连续 push、或 push 后紧接着手动 dispatch 同一分支），先跑的那个会被取消，只有最后一次触发的会真正跑完、推送。避免"旧的那次跑得比新的那次慢，最后把新内容覆盖回旧内容"。
+
+### 3.3 SYNC-004：push 后 SHA 比对
+
+```yaml
+- name: Verify GitLab received the pushed SHA
+  env:
+    GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+    SYNC_BRANCH: ${{ github.event.inputs.branch || github.ref_name }}
+  run: |
+    LOCAL_SHA=$(git rev-parse HEAD)
+    GITLAB_SHA=$(curl -sf --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+      "https://gitlab.com/api/v4/projects/CodesSentinels%2Fai-reviewer/repository/branches/${SYNC_BRANCH}" \
+      | jq -r '.commit.id')
+    if [ "$GITLAB_SHA" != "$LOCAL_SHA" ]; then
+      echo "SYNC FAILED: GitLab $SYNC_BRANCH is at $GITLAB_SHA, expected $LOCAL_SHA" >&2
+      exit 1
+    fi
+    echo "OK: GitLab $SYNC_BRANCH confirmed at $LOCAL_SHA"
+```
+
+用 GitLab REST API（`GET /projects/:id/repository/branches/:branch`）读回 GitLab 那边这个分支当前的 HEAD commit，跟本地刚推送的 `HEAD` 比对。不一致就让 job 失败——这是第 12 章 `ai_review_trigger` 信任链的上游保证：`CI-013` 校验"bundle 记录的 source commit 等于当前 `CI_COMMIT_SHA`"，前提是 GitLab `main` 上的内容确实等于 GitHub `main` 推送时的内容，本步骤就是在验证这个前提。
+
+`jq` 在 GitHub-hosted `ubuntu-latest` runner 上预装，不需要额外安装步骤。
+
+---
+
+## 4. 任务拆分与测试
+
+- `.github/workflows/sync-to-gitlab.yml`：加白名单校验、`concurrency`、SHA 校验三步，不改动已有的 checkout/push 逻辑。
+- `__tests__/workflow-security.test.ts`：复用已有的 workflow 解析基础设施（`loadWorkflows()`），新增 `SYNC-*` 相关 describe 块：
+  - `sync-to-gitlab.yml` 配置了 `concurrency`（`SYNC-003`）。
+  - `workflow_dispatch.inputs.branch` 前面存在一个校验分支白名单的 step（用正则匹配脚本里出现 `main|develop` 形式的 case 语句，防止有人删掉这一步）。
+  - `sync-to-gitlab.yml` 里不存在任何 `needs:`/触发关系指向 `openai-review.yml`，反之亦然（`SYNC-005`/`SYNC-006` 结构性锁定）。
+- 新增一条跨仓库守卫：`src/` 下不得出现 `GITLAB_TOKEN`（区别于 `GITLAB_PAT`/`CI_JOB_TOKEN`）——放进 `arch-guard.test.ts`，跟 `ARCH-005`（禁止读 `execCtx.raw`）那类"防止敏感字符串误用"的守卫是同一种模式（`SYNC-009`）。
+
+---
+
+## 5. 验收标准
+
+- `.github/workflows/sync-to-gitlab.yml` 能被 `js-yaml` 解析，`concurrency`/校验 step/`SYNC-004` 校验 step 均存在。
+- 新增的 workflow-security 测试全部通过。
+- `arch-guard.test.ts` 的 `GITLAB_TOKEN` 守卫测试通过（当前 `src/` 下确实不存在这个字符串，测试锁定这一事实）。
+- `npx tsc --noEmit`/`npm run lint`/`npx jest` 全量通过，不影响既有测试。
+
+---
+
+## 6. 风险与未决问题
+
+- **无法端到端验证**：`SYNC-004` 的 SHA 比对逻辑依赖真实调用 GitLab REST API，本地/CI 环境没有到期有效的 `GITLAB_TOKEN` 和真实 GitLab 项目可供回放，只能靠 shell 脚本走查 + `workflow-security.test.ts` 的静态断言，实际 `curl`/`jq` 调用链路未经真实执行验证。
+- **"GitLab 直接 push/MR merge 被保护规则拒绝"（实施方案 §2.4 验证方法之一）不属于代码改动范围**：这是 GitLab 项目的 Protected Branch 设置，需要在真实 `ai-reviewer-test` 项目里手动配置，本任务无法在代码层面体现或测试。
+- **`SYNC-006`"防止 GitLab pipeline 反向触发 GitHub 写入"**：当前架构下没有任何代码路径尝试这么做，本任务不新增代码，只加测试固化"现状如此"；如果未来有人往 `gitlab-platform.ts`/`gitlab-trigger.ts` 里加了调用 GitHub API 的代码，这条防线要靠 `arch-guard.test.ts` 一类的架构测试才能拦住，而不是本设计文档能覆盖的范围——留给后续任务补测试。


### PR DESCRIPTION
Closes #105

汇总见 #75。设计依据：`docs/tasks/gitlab-sync-hardening-design.md`。互补关系：第 12 章（#102/#103，已完成）验证"信任已经在 GitLab `main` 上的 bundle 来源"，本 PR 负责"让 GitHub `main` 的可信内容真的同步到 GitLab `main`"。

## Summary

`.github/workflows/sync-to-gitlab.yml` 已有基础上新增三步：

- **分支白名单校验**：`workflow_dispatch.inputs.branch` 此前是自由文本输入，没有校验——任何人手动触发都能把仓库里任意分支强推到 GitLab 同名分支。新增 `case` 语句只放行 `main`/`develop`，放在 checkout/拿到 `GITLAB_TOKEN` 之前，校验失败直接退出（`SYNC-002`/`SYNC-008`）。
- **`concurrency`**：按目标分支分组、`cancel-in-progress: true`。之前连续两次 push 到同一分支时，两次同步 job 可能并发跑，完成顺序不保证跟触发顺序一致，存在旧同步覆盖新提交的竞态（`SYNC-003`）。
- **push 后 SHA 比对**：`git push --force` 执行完不代表 GitLab 真的收到了这次推送——新增一步用 GitLab REST API 回读目标分支当前 HEAD，跟本地刚推送的 commit 比对，不一致就让 job 失败（`SYNC-004`）。

已确认满足、未改动的部分：目标仓库 URL 是硬编码字面量（`SYNC-002`）；自动触发只监听 `main`/`develop`，不含 tag（`SYNC-008`）；与 `openai-review.yml` 是完全独立的两个文件，互不 `needs`/`workflow_run`（`SYNC-005`/`SYNC-006`）；`git push` 同 SHA 天然幂等（`SYNC-007`）；`GITLAB_TOKEN`（同步专用）与 GitLab-only 运行时用的 `GITLAB_PAT`/`CI_JOB_TOKEN` 是完全不同的凭据，不重合（`SYNC-009`，新增守卫测试锁定）。

## 测试

- `__tests__/workflow-security.test.ts` 新增 `SYNC-001~009` describe 块（7 项）：白名单校验 step 存在且顺序正确、`concurrency` 配置、push 后校验 step 存在且引用 `LOCAL_SHA`、目标 URL 固定字面量、与 `openai-review.yml` 互不跨文件触发、自动触发白名单。
- `__tests__/arch-guard.test.ts` 新增 `SYNC-009` describe 块（2 项）：`src/` 不出现 `GITLAB_TOKEN`；反向确认 `gitlab-trigger.ts` 确实用的是 `GITLAB_PAT`/`CI_JOB_TOKEN`（防止两个凭据名字都被删掉导致上一条测试空跑）。
- 全量 `npx jest`：1483 passed / 9 skipped，0 failed。
- `npx tsc --noEmit`：clean。`npm run lint`：clean。

## 已知缺口（已在 TODO 文档第 13 章状态说明和设计文档第 6 节记录）

- `SYNC-004` 新增的 `curl`/`jq` 调用 GitLab REST API 的逻辑，没有真实有效的 `GITLAB_TOKEN` 和 GitLab 项目可供回放，只做了脚本走查和 YAML 结构断言。
- GitLab 项目的 Protected Branch 保护规则（拒绝直接 push/MR merge）是项目配置项，本 PR 无法在代码层面体现或测试。

## 不在本任务范围

- 改用 GitLab Pull Mirror（方案文档提到的备选方案）。
- 第 12 章 `CI-*`（已完成）。

## Test plan

- [x] `npx jest` 全量通过
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] 真实同步回放验证（阻塞项：`ai-reviewer-test` 项目尚未接入，见已知缺口）
