### PR TITLE
fix(gitlab): EVENT-003 补齐 HEAD SHA 校验

### DIFF
--- a/__tests__/gitlab-trigger-validation.test.ts
+++ b/__tests__/gitlab-trigger-validation.test.ts
@@ -131,4 +131,76 @@ describe('validateTriggerPayload()', () => {
       reason: 'missing project.id'
     })
   })
+
+  // EVENT-003（GitHub Issue #88 P1 复核）：HEAD SHA 缺失/空值/类型错误必须
+  // fail closed，不能像 gitlab-execution-context.ts 那样静默兜底成空字符串。
+  describe('EVENT-003: HEAD SHA 校验', () => {
+    test('merge_request 缺少 object_attributes.last_commit → ok:false', () => {
+      const payload = {
+        object_kind: 'merge_request',
+        project: {id: 42},
+        object_attributes: {iid: 1, source_project_id: 1, target_project_id: 1}
+      }
+      expect(validateTriggerPayload(payload)).toEqual({
+        ok: false,
+        reason: 'missing or invalid object_attributes.last_commit.id'
+      })
+    })
+
+    test('merge_request 的 last_commit.id 是空字符串 → ok:false', () => {
+      const payload = {
+        object_kind: 'merge_request',
+        project: {id: 42},
+        object_attributes: {
+          iid: 1,
+          source_project_id: 1,
+          target_project_id: 1,
+          last_commit: {id: ''}
+        }
+      }
+      expect(validateTriggerPayload(payload)).toEqual({
+        ok: false,
+        reason: 'missing or invalid object_attributes.last_commit.id'
+      })
+    })
+
+    test('merge_request 的 last_commit.id 类型错误（非字符串）→ ok:false', () => {
+      const payload = {
+        object_kind: 'merge_request',
+        project: {id: 42},
+        object_attributes: {
+          iid: 1,
+          source_project_id: 1,
+          target_project_id: 1,
+          last_commit: {id: 12345}
+        }
+      }
+      expect(validateTriggerPayload(payload)).toEqual({
+        ok: false,
+        reason: 'missing or invalid object_attributes.last_commit.id'
+      })
+    })
+
+    test('note（noteable_type=MergeRequest）缺少 merge_request.diff_head_sha → ok:false', () => {
+      const payload = {
+        object_kind: 'note',
+        project: {id: 42},
+        object_attributes: {id: 1, noteable_type: 'MergeRequest', action: 'create'},
+        merge_request: {iid: 7}
+      }
+      expect(validateTriggerPayload(payload)).toEqual({
+        ok: false,
+        reason: 'missing or invalid merge_request.diff_head_sha'
+      })
+    })
+
+    test('note（noteable_type=Issue）不要求 diff_head_sha 存在 → ok:true（沿用既有 ignorable 分支）', () => {
+      const payload = {
+        object_kind: 'note',
+        project: {id: 42},
+        object_attributes: {id: 1, noteable_type: 'Issue', action: 'create'}
+      }
+      expect(validateTriggerPayload(payload)).toEqual({ok: true})
+    })
+  })
 })

--- a/docs/github-gitlab-compatibility-todo.md
+++ b/docs/github-gitlab-compatibility-todo.md
@@ -352,14 +352,16 @@
 
 - [x] `EVENT-001` 新增 GitLab trigger CLI 源入口。
 - [x] `EVENT-002` CLI 从 file-type `TRIGGER_PAYLOAD` 路径读取原始 payload。
-- [ ] `EVENT-003` CLI 校验 project ID、事件类型、source/target project、MR IID
+- [x] `EVENT-003` CLI 校验 project ID、事件类型、source/target project、MR IID
       和 HEAD SHA。`validateTriggerPayload()`（`gitlab-trigger-validation.ts`）
-      只校验 project ID、事件类型、source/target project、MR IID，**未校验任何
-      HEAD SHA 相关字段**；`createGitLabExecutionContext()` 里
-      `baseSha: attrs.oldrev ?? ''`、`headSha: attrs.last_commit?.id ?? ''` 字段
-      缺失时静默兜底成空字符串，不是 fail closed。此前误勾为已完成（GitHub
-      Issue [#88](https://github.com/CodesSentinels/ai-reviewer/issues/88) P1
-      复核指出），已改回未完成。
+      现在对 HEAD SHA 做 fail closed 校验：`merge_request` 事件要求
+      `object_attributes.last_commit.id` 是非空字符串，`note` 事件（仅当
+      `noteable_type === 'MergeRequest'`）要求 `merge_request.diff_head_sha`
+      是非空字符串，缺失/空值/类型错误统一返回 `ok:false`。此前误勾为已完成，
+      经 GitHub Issue [#88](https://github.com/CodesSentinels/ai-reviewer/issues/88)
+      P1 复核指出缺口后改回未完成；现已补齐 HEAD SHA 校验并重新验证通过（GitHub
+      Issue [#109](https://github.com/CodesSentinels/ai-reviewer/issues/109)
+      跟踪，汇总见 Issue [#75](https://github.com/CodesSentinels/ai-reviewer/issues/75)）。
 - [x] `EVENT-004` 无关事件快速成功退出，不调用模型、不写评论。
 - [x] `EVENT-005` 所有错误日志脱敏，不输出完整 payload 或 Token。
 

--- a/src/gitlab-trigger-validation.ts
+++ b/src/gitlab-trigger-validation.ts
@@ -42,6 +42,14 @@ export function validateTriggerPayload(payload: unknown): TriggerPayloadValidati
     if (attrs?.source_project_id == null || attrs?.target_project_id == null) {
       return {ok: false, reason: 'missing source_project_id/target_project_id'}
     }
+    // EVENT-003（GitHub Issue #88 P1 复核）：GitLab 官方 Merge Request events
+    // 文档里 object_attributes.last_commit 在所有 action 下都会出现，用来描述
+    // 当前 HEAD——缺失/空值/类型错误一律 fail closed，不能像
+    // gitlab-execution-context.ts 里 `attrs.last_commit?.id ?? ''` 那样静默兜底
+    // 成空字符串（那会让 EVENT-008 拿着一个假的空 headSha 继续跑下去）。
+    if (!isNonEmptyString(attrs?.last_commit?.id)) {
+      return {ok: false, reason: 'missing or invalid object_attributes.last_commit.id'}
+    }
     return {
       ok: true,
       sourceTargetMismatch: attrs.source_project_id !== attrs.target_project_id
@@ -59,8 +67,19 @@ export function validateTriggerPayload(payload: unknown): TriggerPayloadValidati
   // 那是需要交给 createGitLabExecutionContext 判定 ignorable_event 的正常
   // 情况，不是结构校验失败。只有"明明是 MergeRequest 的评论却没带 merge_request"
   // 才是这里要拦的真正结构性缺失。
-  if (attrs?.noteable_type === MERGE_REQUEST_NOTEABLE_TYPE && mr?.iid == null) {
-    return {ok: false, reason: 'missing merge_request.iid'}
+  if (attrs?.noteable_type === MERGE_REQUEST_NOTEABLE_TYPE) {
+    if (mr?.iid == null) {
+      return {ok: false, reason: 'missing merge_request.iid'}
+    }
+    // EVENT-003：Note Hook 里 HEAD SHA 对应字段是 merge_request.diff_head_sha
+    // （见 gitlab-execution-context.ts 的 headSha 取值），同样不允许缺失/空值。
+    if (!isNonEmptyString(mr?.diff_head_sha)) {
+      return {ok: false, reason: 'missing or invalid merge_request.diff_head_sha'}
+    }
   }
   return {ok: true}
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value !== ''
 }


### PR DESCRIPTION
Closes #109

汇总见 #75。缺口最初由 #88 P1 复核指出。

## Summary
- `validateTriggerPayload()`（`src/gitlab-trigger-validation.ts`）新增 HEAD SHA 校验：`merge_request` 事件要求 `object_attributes.last_commit.id` 非空字符串；`note` 事件（仅当 `noteable_type === 'MergeRequest'`）要求 `merge_request.diff_head_sha` 非空字符串。缺失/空值/类型错误统一 `ok:false`，`gitlab-trigger.ts` 据此 fail closed。
- `note` 事件的校验沿用既有模式：只在确认是 MR note 时才要求相关字段，避免误伤 Issue/commit/snippet 上的评论（那些场景本来就没有 `merge_request` 字段，交给 `createGitLabExecutionContext` 判定 `ignorable_event`）。

## Test plan
- [x] 新增 6 项测试覆盖 MR/Note 两种事件的缺失/空值/类型错误
- [x] 复用既有 fixture 确认成功场景不受影响（fixture 本来就有正确的 HEAD SHA 字段）
- [x] `npx jest` 全量 1761 passed / 0 failed
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean

## 不在本任务范围
- `EVENT-012`/`EVENT-013`/`EVENT-020`/`EVENT-021`——依赖 `STATE-005`（第 10 章），另行跟踪。
